### PR TITLE
Use solid background on homepage

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -7,6 +7,7 @@ body.home {
     position: relative;
     min-height: 100vh;
     overflow-x: hidden;
+    background-color: #000;
 }
 
 body.home main.home-main {
@@ -15,6 +16,7 @@ body.home main.home-main {
 }
 
 #home-splash {
+    display: none;
     position: fixed;
     top: 0;
     right: 0;
@@ -22,7 +24,6 @@ body.home main.home-main {
     left: 0;
     width: 100vw;
     height: 100vh;
-    display: block;
     pointer-events: none;
     z-index: -1;
     opacity: 0.55;


### PR DESCRIPTION
## Summary
- set the homepage body to use the same black background color as doc pages
- hide the WebGL splash canvas so the home background is a solid color while keeping the animation code in place

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951cddbf360832789e14817b3d5a347)