### PR TITLE
blog: clickable tags + tag pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ from flask import Flask, render_template, abort, send_from_directory
 import markdown
 from pygments.formatters import HtmlFormatter
 import os
+import re
+import unicodedata
 from markdown.extensions import Extension
 from markdown.extensions import tables
 from markdown.extensions import sane_lists
@@ -53,6 +55,93 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 POSTS_DIR = os.path.join(BASE_DIR, 'posts')
 BETA_BUILD_DIR = os.path.join(BASE_DIR, 'build', 'beta')
 
+UNPUBLISHED_TAGS = {"Stub", "Draft", "Unlisted"}
+
+
+def _normalize_tags(raw_tags) -> list[str]:
+    # Make tags proper case, if the tag is not already all caps
+    tags = [tag.title() if isinstance(tag, str) and not tag.isupper() else tag for tag in (raw_tags or [])]
+
+    # a few canonical replacements
+    tags = [t.replace("Arcgis Pro", "ArcGIS Pro") if isinstance(t, str) else t for t in tags]
+    tags = [t.replace("Ai", "AI") if isinstance(t, str) else t for t in tags]
+    tags = [t.replace("Gis", "GIS") if isinstance(t, str) else t for t in tags]
+
+    # filter empties + coerce to strings
+    return [str(t).strip() for t in tags if str(t).strip()]
+
+
+def tag_slug(tag: str) -> str:
+    """Convert a display tag into a stable URL slug."""
+    if not tag:
+        return ""
+
+    # normalize unicode
+    value = unicodedata.normalize("NFKD", str(tag))
+    value = value.encode("ascii", "ignore").decode("ascii")
+
+    value = value.lower().strip()
+    value = value.replace("&", "and")
+    value = re.sub(r"[^a-z0-9\s-]", "", value)
+    value = re.sub(r"[\s_-]+", "-", value)
+    value = re.sub(r"^-+|-+$", "", value)
+    return value
+
+
+def _parse_post_file(filename: str) -> dict | None:
+    """Parse a markdown post and return metadata for lists (not full HTML)."""
+    if not filename.endswith('.md'):
+        return None
+
+    with open(os.path.join(POSTS_DIR, filename), 'r', encoding='utf-8', errors='ignore') as file:
+        content = file.read()
+
+    metadata = {}
+    body = content
+
+    # Try to parse YAML front matter
+    try:
+        if content.startswith('---'):
+            _, front_matter, body = content.split('---\n', 2)
+            metadata = yaml.safe_load(front_matter) or {}
+    except (ValueError, IndexError, yaml.YAMLError):
+        metadata = {}
+
+    title = metadata.get('title', filename[:-3])
+    date_str = metadata.get('date')
+
+    if isinstance(date_str, str):
+        date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+    elif isinstance(date_str, datetime):
+        date_obj = date_str
+    elif isinstance(date_str, date):
+        date_obj = datetime.combine(date_str, datetime.min.time())
+    else:
+        file_creation_time = os.path.getctime(os.path.join(POSTS_DIR, filename))
+        date_obj = datetime.fromtimestamp(file_creation_time)
+
+    tags = _normalize_tags(metadata.get('tags', []))
+    tag_objs = [{"name": t, "slug": tag_slug(t)} for t in tags if t not in UNPUBLISHED_TAGS]
+
+    return {
+        'name': filename[:-3],
+        'title': title,
+        'date': date_obj,
+        'tags': tags,
+        'tag_objs': tag_objs,
+    }
+
+
+def _list_posts() -> list[dict]:
+    posts = []
+    for f in os.listdir(POSTS_DIR):
+        parsed = _parse_post_file(f)
+        if parsed:
+            posts.append(parsed)
+
+    posts.sort(key=lambda x: x['date'], reverse=True)
+    return posts
+
 
 def _resolve_beta_resource(resource: str) -> str | None:
     """Return the relative path to a beta asset if it exists."""
@@ -77,65 +166,8 @@ def _resolve_beta_resource(resource: str) -> str | None:
 
 @app.route('/')
 def index():
-    posts = []
-    for f in os.listdir(POSTS_DIR):
-        # print file name for debugging
-        print(f)
-        if f.endswith('.md'):
-            with open(os.path.join(POSTS_DIR, f), 'r', encoding='utf-8', errors='ignore') as file:
-                content = file.read()
-                metadata = {}
-                body = content
-                
-                # Try to parse YAML front matter
-                try:
-                    if content.startswith('---'):
-                        _, front_matter, body = content.split('---\n', 2)
-                        metadata = yaml.safe_load(front_matter)
-                except (ValueError, IndexError, yaml.YAMLError):
-                    pass
-
-                # Extract or default title and date
-                title = metadata.get('title', f[:-3])
-                date_str = metadata.get('date')
-                
-                if isinstance(date_str, str):
-                    date_obj = datetime.strptime(date_str, '%Y-%m-%d')
-                elif isinstance(date_str, datetime):
-                    date_obj = date_str
-                elif isinstance(date_str, date):
-                    # Convert date to datetime for consistency
-                    date_obj = datetime.combine(date_str, datetime.min.time())
-                else:
-                    # Fallback to the file's creation date
-                    file_creation_time = os.path.getctime(os.path.join(POSTS_DIR, f))
-                    date_obj = datetime.fromtimestamp(file_creation_time)
-
-                               
-                # Make tags proper case, if the tag is not already all caps
-                tags = [tag.title() if not tag.isupper() else tag for tag in metadata.get('tags', [])]
-                # if the tag is "Arcgis Pro", replace it with "ArcGIS Pro"
-                if "Arcgis Pro" in tags:
-                    tags = [tag.replace("Arcgis Pro", "ArcGIS Pro") for tag in tags]
-                if "Ai" in tags:
-                    tags = [tag.replace("Ai", "AI") for tag in tags]
-                if "Gis" in tags:
-                    tags = [tag.replace("Gis", "GIS") for tag in tags]
-
-
-                posts.append({
-                    'name': f[:-3],  # Remove the .md extension
-                    'title': title,
-                    'date': date_obj,
-                    'tags': tags,
-                })
-
-    # Sort posts by date in descending order (newest first)
-    posts.sort(key=lambda x: x['date'], reverse=True)
-    # sort posts randomly
-    # posts.sort(key=lambda x: random.random())
-
-    return render_template('index.html', posts=posts)
+    posts = _list_posts()
+    return render_template('index.html', posts=posts, UNPUBLISHED_TAGS=UNPUBLISHED_TAGS)
 
 
 @app.route('/beta', defaults={'resource': ''}, strict_slashes=False)
@@ -163,14 +195,10 @@ def post(post_name):
 
         # Extract title, tags, and date from metadata
         title = metadata.get('title', post_name)
-        tags = metadata.get('tags', [])
         date_str = metadata.get('date')
 
-        # Make tags proper case, if the tag is not already all caps
-        tags = [tag.title() if not tag.isupper() else tag for tag in metadata.get('tags', [])]
-        # if the tag is "Arcgis Pro", replace it with "ArcGIS Pro"
-        if "Arcgis Pro" in tags:
-            tags = [tag.replace("Arcgis Pro", "ArcGIS Pro") for tag in tags]
+        tags = _normalize_tags(metadata.get('tags', []))
+        tag_objs = [{"name": t, "slug": tag_slug(t)} for t in tags if t not in UNPUBLISHED_TAGS]
 
         # Handle date conversion if needed
         if isinstance(date_str, str):
@@ -209,11 +237,47 @@ def post(post_name):
         pygments_css = formatter.get_style_defs()
 
         # Render the template with all necessary data
-        return render_template('post.html', content=html_content, title=title, pygments_css=pygments_css, tags=tags, date=date_obj)
+        return render_template(
+            'post.html',
+            content=html_content,
+            title=title,
+            pygments_css=pygments_css,
+            tags=tags,
+            tag_objs=tag_objs,
+            date=date_obj,
+        )
         
     
     except FileNotFoundError:
         abort(404)
+
+
+@app.route('/tag/<tag_slug_value>.html')
+def tag(tag_slug_value: str):
+    posts = _list_posts()
+
+    # Find canonical display tag for this slug
+    canonical = None
+    for p in posts:
+        for t in p.get('tags', []):
+            if tag_slug(t) == tag_slug_value:
+                canonical = t
+                break
+        if canonical:
+            break
+
+    if not canonical:
+        abort(404)
+
+    # Filter posts by tag + hide unpublished
+    filtered = []
+    for p in posts:
+        if any(t == canonical for t in p.get('tags', [])):
+            if any(t in UNPUBLISHED_TAGS for t in p.get('tags', [])):
+                continue
+            filtered.append(p)
+
+    return render_template('tag.html', tag_name=canonical, posts=filtered, UNPUBLISHED_TAGS=UNPUBLISHED_TAGS)
 
 
 if __name__ == '__main__':

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,11 +56,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Agents</span>
+                <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
                 
-                <span class="post-tag">Workflow</span>
+                <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
                 
               </div>
               
@@ -84,11 +84,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Agents</span>
+                <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
                 
               </div>
               
@@ -112,11 +112,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
                 
               </div>
               
@@ -140,15 +140,15 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Side-Projects</span>
+                <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a>
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Javascript</span>
+                <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
                 
               </div>
               
@@ -172,15 +172,15 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Data Engineering</span>
+                <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a>
                 
-                <span class="post-tag">Pipelines</span>
+                <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a>
                 
-                <span class="post-tag">Careers</span>
+                <a class="post-tag tag-link" href="/tag/careers.html">Careers</a>
                 
-                <span class="post-tag">Systems Thinking</span>
+                <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
                 
               </div>
               
@@ -204,13 +204,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Workflows</span>
+                <a class="post-tag tag-link" href="/tag/workflows.html">Workflows</a>
                 
-                <span class="post-tag">Automation</span>
+                <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
                 
               </div>
               
@@ -234,13 +234,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
-                <span class="post-tag">Strategy</span>
+                <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
                 
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
                 
               </div>
               
@@ -264,9 +264,9 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Meta</span>
+                <a class="post-tag tag-link" href="/tag/meta.html">Meta</a>
                 
-                <span class="post-tag">Workflow</span>
+                <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
                 
               </div>
               
@@ -290,13 +290,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Career</span>
+                <a class="post-tag tag-link" href="/tag/career.html">Career</a>
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
-                <span class="post-tag">Technology</span>
+                <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
                 
               </div>
               
@@ -320,13 +320,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Career</span>
+                <a class="post-tag tag-link" href="/tag/career.html">Career</a>
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
-                <span class="post-tag">Technology</span>
+                <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
                 
               </div>
               
@@ -350,13 +350,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
                 
-                <span class="post-tag">Technology</span>
+                <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
                 
               </div>
               
@@ -380,11 +380,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
-                <span class="post-tag">Strategy</span>
+                <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
                 
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
                 
               </div>
               
@@ -408,11 +408,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Tools</span>
+                <a class="post-tag tag-link" href="/tag/tools.html">Tools</a>
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
                 
               </div>
               
@@ -436,9 +436,9 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Data</span>
+                <a class="post-tag tag-link" href="/tag/data.html">Data</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
               </div>
               
@@ -470,11 +470,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Arcgis</span>
+                <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
               </div>
               
@@ -498,11 +498,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Automation</span>
+                <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
                 
               </div>
               
@@ -526,11 +526,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Python</span>
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a>
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Arcgis</span>
+                <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
                 
               </div>
               
@@ -554,13 +554,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Programming</span>
+                <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
                 
-                <span class="post-tag">Python</span>
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a>
                 
-                <span class="post-tag">Teamwork</span>
+                <a class="post-tag tag-link" href="/tag/teamwork.html">Teamwork</a>
                 
-                <span class="post-tag">Notebooks</span>
+                <a class="post-tag tag-link" href="/tag/notebooks.html">Notebooks</a>
                 
               </div>
               
@@ -584,13 +584,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Programming</span>
+                <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
                 
-                <span class="post-tag">AI</span>
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
                 
-                <span class="post-tag">Databases</span>
+                <a class="post-tag tag-link" href="/tag/databases.html">Databases</a>
                 
-                <span class="post-tag">Data</span>
+                <a class="post-tag tag-link" href="/tag/data.html">Data</a>
                 
               </div>
               
@@ -614,11 +614,11 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Python</span>
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a>
                 
-                <span class="post-tag">Open-Source</span>
+                <a class="post-tag tag-link" href="/tag/open-source.html">Open-Source</a>
                 
               </div>
               
@@ -642,7 +642,7 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Personal</span>
+                <a class="post-tag tag-link" href="/tag/personal.html">Personal</a>
                 
               </div>
               
@@ -666,9 +666,9 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">Health</span>
+                <a class="post-tag tag-link" href="/tag/health.html">Health</a>
                 
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
                 
               </div>
               
@@ -692,13 +692,13 @@ Danny McVey
               
               <div class="post-tags bg-dark">
                 
-                <span class="post-tag">GIS</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
                 
-                <span class="post-tag">Python</span>
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a>
                 
-                <span class="post-tag">Streamlit</span>
+                <a class="post-tag tag-link" href="/tag/streamlit.html">Streamlit</a>
                 
-                <span class="post-tag">Spatial-Analysis</span>
+                <a class="post-tag tag-link" href="/tag/spatial-analysis.html">Spatial-Analysis</a>
                 
               </div>
               

--- a/docs/post/Empowering-GIS-With-AI.html
+++ b/docs/post/Empowering-GIS-With-AI.html
@@ -203,11 +203,11 @@ The AI can guide you step-by-step, improving the efficiency of your analysis.</p
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Ai</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Automation</span>
+                <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
             
         </p>
         

--- a/docs/post/a-gis-analyst-from-the-future.html
+++ b/docs/post/a-gis-analyst-from-the-future.html
@@ -255,13 +255,13 @@ It is calmer, clearer, and easier to think in.</p>
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">GIS</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Workflows</span> 
+                <a class="post-tag tag-link" href="/tag/workflows.html">Workflows</a> 
             
-                <span class="post-tag">Automation</span>
+                <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
             
         </p>
         

--- a/docs/post/about-me.html
+++ b/docs/post/about-me.html
@@ -147,7 +147,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Personal</span>
+                <a class="post-tag tag-link" href="/tag/personal.html">Personal</a>
             
         </p>
         

--- a/docs/post/adapt-or-get-left-behind.html
+++ b/docs/post/adapt-or-get-left-behind.html
@@ -156,13 +156,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Career</span> 
+                <a class="post-tag tag-link" href="/tag/career.html">Career</a> 
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Technology</span>
+                <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
             
         </p>
         

--- a/docs/post/ai-gp-tools.html
+++ b/docs/post/ai-gp-tools.html
@@ -140,11 +140,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Ai</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Arcgis</span> 
+                <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a> 
             
-                <span class="post-tag">Gis</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
             
         </p>
         

--- a/docs/post/arcpy-tool-alternatives.html
+++ b/docs/post/arcpy-tool-alternatives.html
@@ -199,11 +199,11 @@ print(f"ArcPy area: {arcpy_area}, GeoPandas area: {gpd_area}")
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Python</span> 
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a> 
             
-                <span class="post-tag">Open-Source</span>
+                <a class="post-tag tag-link" href="/tag/open-source.html">Open-Source</a>
             
         </p>
         

--- a/docs/post/damn field maps.html
+++ b/docs/post/damn field maps.html
@@ -192,11 +192,11 @@ def create_field_mappings(target, join, join_field, output_field_name=None, merg
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Python</span> 
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a> 
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Arcgis</span>
+                <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
             
         </p>
         

--- a/docs/post/demystifying-agent-jargon.html
+++ b/docs/post/demystifying-agent-jargon.html
@@ -188,11 +188,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Agents</span> 
+                <a class="post-tag tag-link" href="/tag/agents.html">Agents</a> 
             
-                <span class="post-tag">Workflow</span>
+                <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
             
         </p>
         

--- a/docs/post/from-gis-projects-to-data-pipelines.html
+++ b/docs/post/from-gis-projects-to-data-pipelines.html
@@ -205,15 +205,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Data Engineering</span> 
+                <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a> 
             
-                <span class="post-tag">Pipelines</span> 
+                <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a> 
             
-                <span class="post-tag">Careers</span> 
+                <a class="post-tag tag-link" href="/tag/careers.html">Careers</a> 
             
-                <span class="post-tag">Systems Thinking</span>
+                <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
             
         </p>
         

--- a/docs/post/gis-careers-ai-evolution.html
+++ b/docs/post/gis-careers-ai-evolution.html
@@ -205,13 +205,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Ai</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Work</span> 
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a> 
             
-                <span class="post-tag">Technology</span>
+                <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
             
         </p>
         

--- a/docs/post/high-leverage-focus.html
+++ b/docs/post/high-leverage-focus.html
@@ -207,11 +207,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Strategy</span> 
+                <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a> 
             
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
             
         </p>
         

--- a/docs/post/how-the-blog-is-built.html
+++ b/docs/post/how-the-blog-is-built.html
@@ -149,9 +149,9 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Meta</span> 
+                <a class="post-tag tag-link" href="/tag/meta.html">Meta</a> 
             
-                <span class="post-tag">Workflow</span>
+                <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
             
         </p>
         

--- a/docs/post/memory-considerations-spatial-data.html
+++ b/docs/post/memory-considerations-spatial-data.html
@@ -179,9 +179,9 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Data</span> 
+                <a class="post-tag tag-link" href="/tag/data.html">Data</a> 
             
-                <span class="post-tag">Gis</span>
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
             
         </p>
         

--- a/docs/post/numpad.html
+++ b/docs/post/numpad.html
@@ -188,11 +188,11 @@ CreateNumpadKeys() {
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Tools</span> 
+                <a class="post-tag tag-link" href="/tag/tools.html">Tools</a> 
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
             
         </p>
         

--- a/docs/post/prioritizing-health.html
+++ b/docs/post/prioritizing-health.html
@@ -153,9 +153,9 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Health</span> 
+                <a class="post-tag tag-link" href="/tag/health.html">Health</a> 
             
-                <span class="post-tag">Productivity</span>
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
             
         </p>
         

--- a/docs/post/problems-to-solve.html
+++ b/docs/post/problems-to-solve.html
@@ -141,13 +141,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Stub</span> 
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a> 
             
-                <span class="post-tag">Work</span> 
+                <a class="post-tag tag-link" href="/tag/personal.html">Personal</a> 
             
-                <span class="post-tag">Personal</span> 
-            
-                <span class="post-tag">Motivation</span>
+                <a class="post-tag tag-link" href="/tag/motivation.html">Motivation</a>
             
         </p>
         

--- a/docs/post/proximity-analysis-with-streamlit.html
+++ b/docs/post/proximity-analysis-with-streamlit.html
@@ -281,13 +281,13 @@ distance_threshold_meters = feet_to_meters(distance_threshold_feet)
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Python</span> 
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a> 
             
-                <span class="post-tag">Streamlit</span> 
+                <a class="post-tag tag-link" href="/tag/streamlit.html">Streamlit</a> 
             
-                <span class="post-tag">Spatial-Analysis</span>
+                <a class="post-tag tag-link" href="/tag/spatial-analysis.html">Spatial-Analysis</a>
             
         </p>
         

--- a/docs/post/purpose-driven-process.html
+++ b/docs/post/purpose-driven-process.html
@@ -181,11 +181,9 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Work</span> 
-            
-                <span class="post-tag">Stub</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
             
         </p>
         

--- a/docs/post/removing-work-is-the-real-ai-leverage.html
+++ b/docs/post/removing-work-is-the-real-ai-leverage.html
@@ -151,11 +151,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Ai</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
             
         </p>
         

--- a/docs/post/sharing-python-tools.html
+++ b/docs/post/sharing-python-tools.html
@@ -221,13 +221,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Programming</span> 
+                <a class="post-tag tag-link" href="/tag/programming.html">Programming</a> 
             
-                <span class="post-tag">Python</span> 
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a> 
             
-                <span class="post-tag">Teamwork</span> 
+                <a class="post-tag tag-link" href="/tag/teamwork.html">Teamwork</a> 
             
-                <span class="post-tag">Notebooks</span>
+                <a class="post-tag tag-link" href="/tag/notebooks.html">Notebooks</a>
             
         </p>
         

--- a/docs/post/spatial-index.html
+++ b/docs/post/spatial-index.html
@@ -184,13 +184,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Data</span> 
+                <a class="post-tag tag-link" href="/tag/data.html">Data</a> 
             
-                <span class="post-tag">Work</span> 
-            
-                <span class="post-tag">Stub</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
             
         </p>
         

--- a/docs/post/spatial-workbench-ecosystem.html
+++ b/docs/post/spatial-workbench-ecosystem.html
@@ -190,11 +190,11 @@ PyPI: <a href="https://pypi.org/project/arcgispro-cli/">pypi.org/project/arcgisp
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">GIS</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Agents</span>
+                <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
             
         </p>
         

--- a/docs/post/teaching-python.html
+++ b/docs/post/teaching-python.html
@@ -133,13 +133,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Programming</span> 
+                <a class="post-tag tag-link" href="/tag/programming.html">Programming</a> 
             
-                <span class="post-tag">Python</span> 
+                <a class="post-tag tag-link" href="/tag/python.html">Python</a> 
             
-                <span class="post-tag">Education</span> 
-            
-                <span class="post-tag">Stub</span>
+                <a class="post-tag tag-link" href="/tag/education.html">Education</a>
             
         </p>
         

--- a/docs/post/too-easy-to-start.html
+++ b/docs/post/too-easy-to-start.html
@@ -180,13 +180,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Career</span> 
+                <a class="post-tag tag-link" href="/tag/career.html">Career</a> 
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Technology</span>
+                <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
             
         </p>
         

--- a/docs/post/vector-dbs.html
+++ b/docs/post/vector-dbs.html
@@ -250,13 +250,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Programming</span> 
+                <a class="post-tag tag-link" href="/tag/programming.html">Programming</a> 
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Databases</span> 
+                <a class="post-tag tag-link" href="/tag/databases.html">Databases</a> 
             
-                <span class="post-tag">Data</span>
+                <a class="post-tag tag-link" href="/tag/data.html">Data</a>
             
         </p>
         

--- a/docs/post/vibe-coded-camreview.html
+++ b/docs/post/vibe-coded-camreview.html
@@ -239,15 +239,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Side-Projects</span> 
+                <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a> 
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Gis</span> 
+                <a class="post-tag tag-link" href="/tag/gis.html">GIS</a> 
             
-                <span class="post-tag">Javascript</span>
+                <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
             
         </p>
         

--- a/docs/post/vibe-coding-bike-shedding-real-work.html
+++ b/docs/post/vibe-coding-bike-shedding-real-work.html
@@ -161,13 +161,13 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">Productivity</span> 
+                <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a> 
             
-                <span class="post-tag">Strategy</span> 
+                <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a> 
             
-                <span class="post-tag">Work</span>
+                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
             
         </p>
         

--- a/docs/post/x402-agent-economy-draft.html
+++ b/docs/post/x402-agent-economy-draft.html
@@ -248,17 +248,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         
         <p class="post-tags text-light">
             
-                <span class="post-tag">Draft</span> 
+                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
             
-                <span class="post-tag">AI</span> 
+                <a class="post-tag tag-link" href="/tag/agents.html">Agents</a> 
             
-                <span class="post-tag">Agents</span> 
+                <a class="post-tag tag-link" href="/tag/economics.html">Economics</a> 
             
-                <span class="post-tag">Economics</span> 
+                <a class="post-tag tag-link" href="/tag/x402.html">X402</a> 
             
-                <span class="post-tag">X402</span> 
-            
-                <span class="post-tag">Resilience</span>
+                <a class="post-tag tag-link" href="/tag/resilience.html">Resilience</a>
             
         </p>
         

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -187,11 +187,20 @@ pre code {
     font-size: 0.8em;
     margin-left: 5px;
     display: inline-block;
-    transition: background-color 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+a.post-tag {
+    text-decoration: none;
+}
+
+a.post-tag:hover {
+    text-decoration: none;
 }
 
 .post-tag:hover {
     background-color: #666;
+    color: #fff;
 }
 
 .post-card-link {

--- a/docs/tag/agents.html
+++ b/docs/tag/agents.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Agents</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Agents</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/demystifying-agent-jargon.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Demystifying Agent Jargon So You Can Actually Use This Stuff</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/17/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/spatial-workbench-ecosystem.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Toward a Spatial Workbench Ecosystem</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/16/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/ai.html
+++ b/docs/tag/ai.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: AI</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: AI</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/demystifying-agent-jargon.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Demystifying Agent Jargon So You Can Actually Use This Stuff</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/17/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/spatial-workbench-ecosystem.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Toward a Spatial Workbench Ecosystem</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/16/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/removing-work-is-the-real-ai-leverage.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Removing Work Is the Real AI Leverage</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/11/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coded-camreview.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe coding CamReview: a trail cam app I actually use</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">01/30/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/a-gis-analyst-from-the-future.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">A GIS Analyst From the Future</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/16/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflows.html">Workflows</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coding-bike-shedding-real-work.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe Coding, Bike Shedding, and the Real Work</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/12/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/too-easy-to-start.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Too Easy to Start - AI Tools Shifted My Bottleneck from Building to Shipping</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">04/23/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/adapt-or-get-left-behind.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Adapt or Get Left Behind - The New AI Skillset</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/25/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/gis-careers-ai-evolution.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">The Evolution of GIS Careers in the Age of Advanced AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/11/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/ai-gp-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">AI enhanced GP tools in ArcGIS Pro</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/09/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/Empowering-GIS-With-AI.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Empowering Geospatial Workflows with Generative AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/05/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vector-dbs.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">What are Vector Databases?</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/18/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/databases.html">Databases</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data.html">Data</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/arcgis.html
+++ b/docs/tag/arcgis.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Arcgis</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Arcgis</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/ai-gp-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">AI enhanced GP tools in ArcGIS Pro</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/09/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/damn%20field%20maps.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Field Mapping Frustrations in GIS - Automating Spatial Joins</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/21/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/automation.html
+++ b/docs/tag/automation.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Automation</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Automation</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/a-gis-analyst-from-the-future.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">A GIS Analyst From the Future</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/16/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflows.html">Workflows</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/Empowering-GIS-With-AI.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Empowering Geospatial Workflows with Generative AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/05/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/career.html
+++ b/docs/tag/career.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Career</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Career</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/too-easy-to-start.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Too Easy to Start - AI Tools Shifted My Bottleneck from Building to Shipping</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">04/23/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/adapt-or-get-left-behind.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Adapt or Get Left Behind - The New AI Skillset</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/25/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/careers.html
+++ b/docs/tag/careers.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Careers</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Careers</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/from-gis-projects-to-data-pipelines.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">From GIS Projects to Data Pipelines</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/29/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/careers.html">Careers</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/data-engineering.html
+++ b/docs/tag/data-engineering.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Data Engineering</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Data Engineering</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/from-gis-projects-to-data-pipelines.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">From GIS Projects to Data Pipelines</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/29/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/careers.html">Careers</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/data.html
+++ b/docs/tag/data.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Data</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Data</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/memory-considerations-spatial-data.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Considerations for Spatial Data That Doesn&#39;t Fit in Memory</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/27/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/data.html">Data</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vector-dbs.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">What are Vector Databases?</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/18/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/databases.html">Databases</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data.html">Data</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/databases.html
+++ b/docs/tag/databases.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Databases</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Databases</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/vector-dbs.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">What are Vector Databases?</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/18/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/databases.html">Databases</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data.html">Data</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/economics.html
+++ b/docs/tag/economics.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Economics</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Economics</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <p>No posts found for this tag.</p>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/education.html
+++ b/docs/tag/education.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Education</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Education</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <p>No posts found for this tag.</p>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/gis.html
+++ b/docs/tag/gis.html
@@ -1,0 +1,396 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: GIS</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: GIS</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/spatial-workbench-ecosystem.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Toward a Spatial Workbench Ecosystem</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/16/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/removing-work-is-the-real-ai-leverage.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Removing Work Is the Real AI Leverage</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/11/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coded-camreview.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe coding CamReview: a trail cam app I actually use</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">01/30/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/from-gis-projects-to-data-pipelines.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">From GIS Projects to Data Pipelines</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/29/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/careers.html">Careers</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/a-gis-analyst-from-the-future.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">A GIS Analyst From the Future</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/16/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflows.html">Workflows</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/gis-careers-ai-evolution.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">The Evolution of GIS Careers in the Age of Advanced AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/11/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/memory-considerations-spatial-data.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Considerations for Spatial Data That Doesn&#39;t Fit in Memory</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/27/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/data.html">Data</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/ai-gp-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">AI enhanced GP tools in ArcGIS Pro</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/09/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/Empowering-GIS-With-AI.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Empowering Geospatial Workflows with Generative AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">09/05/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/damn%20field%20maps.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Field Mapping Frustrations in GIS - Automating Spatial Joins</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/21/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/arcpy-tool-alternatives.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Open source alternatives to ArcPy</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/13/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/open-source.html">Open-Source</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/proximity-analysis-with-streamlit.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Automating Proximity Analysis in Streamlit with Open Source Python</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">07/01/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/streamlit.html">Streamlit</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/spatial-analysis.html">Spatial-Analysis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/health.html
+++ b/docs/tag/health.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Health</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Health</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/prioritizing-health.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Prioritizing Health as a Knowledge Worker</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/01/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/health.html">Health</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/javascript.html
+++ b/docs/tag/javascript.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Javascript</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Javascript</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coded-camreview.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe coding CamReview: a trail cam app I actually use</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">01/30/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/meta.html
+++ b/docs/tag/meta.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Meta</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Meta</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/how-the-blog-is-built.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">How the Blog Is Built</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">05/15/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/meta.html">Meta</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/motivation.html
+++ b/docs/tag/motivation.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Motivation</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Motivation</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <p>No posts found for this tag.</p>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/notebooks.html
+++ b/docs/tag/notebooks.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Notebooks</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Notebooks</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/sharing-python-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Sharing Python Tools - Practical Solutions and Considerations</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/20/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/teamwork.html">Teamwork</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/notebooks.html">Notebooks</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/open-source.html
+++ b/docs/tag/open-source.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Open-Source</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Open-Source</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/arcpy-tool-alternatives.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Open source alternatives to ArcPy</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/13/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/open-source.html">Open-Source</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/personal.html
+++ b/docs/tag/personal.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Personal</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Personal</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/about-me.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">About me</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/02/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/personal.html">Personal</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/pipelines.html
+++ b/docs/tag/pipelines.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Pipelines</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Pipelines</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/from-gis-projects-to-data-pipelines.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">From GIS Projects to Data Pipelines</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/29/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/careers.html">Careers</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/productivity.html
+++ b/docs/tag/productivity.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Productivity</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Productivity</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coded-camreview.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe coding CamReview: a trail cam app I actually use</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">01/30/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coding-bike-shedding-real-work.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe Coding, Bike Shedding, and the Real Work</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/12/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/too-easy-to-start.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Too Easy to Start - AI Tools Shifted My Bottleneck from Building to Shipping</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">04/23/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/adapt-or-get-left-behind.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Adapt or Get Left Behind - The New AI Skillset</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/25/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/high-leverage-focus.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">High-Leverage Focus - Maximizing Impact</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/17/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/numpad.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Creating a Virtual Numpad with AutoHotKey</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">10/09/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/tools.html">Tools</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/prioritizing-health.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Prioritizing Health as a Knowledge Worker</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/01/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/health.html">Health</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/programming.html
+++ b/docs/tag/programming.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Programming</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Programming</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/sharing-python-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Sharing Python Tools - Practical Solutions and Considerations</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/20/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/teamwork.html">Teamwork</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/notebooks.html">Notebooks</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vector-dbs.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">What are Vector Databases?</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/18/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/databases.html">Databases</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data.html">Data</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/python.html
+++ b/docs/tag/python.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Python</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Python</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/damn%20field%20maps.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Field Mapping Frustrations in GIS - Automating Spatial Joins</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/21/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/arcgis.html">Arcgis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/sharing-python-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Sharing Python Tools - Practical Solutions and Considerations</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/20/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/teamwork.html">Teamwork</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/notebooks.html">Notebooks</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/arcpy-tool-alternatives.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Open source alternatives to ArcPy</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/13/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/open-source.html">Open-Source</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/proximity-analysis-with-streamlit.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Automating Proximity Analysis in Streamlit with Open Source Python</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">07/01/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/streamlit.html">Streamlit</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/spatial-analysis.html">Spatial-Analysis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/resilience.html
+++ b/docs/tag/resilience.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Resilience</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Resilience</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <p>No posts found for this tag.</p>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/side-projects.html
+++ b/docs/tag/side-projects.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Side-Projects</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Side-Projects</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coded-camreview.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe coding CamReview: a trail cam app I actually use</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">01/30/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/side-projects.html">Side-Projects</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/javascript.html">Javascript</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/spatial-analysis.html
+++ b/docs/tag/spatial-analysis.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Spatial-Analysis</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Spatial-Analysis</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/proximity-analysis-with-streamlit.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Automating Proximity Analysis in Streamlit with Open Source Python</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">07/01/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/streamlit.html">Streamlit</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/spatial-analysis.html">Spatial-Analysis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/strategy.html
+++ b/docs/tag/strategy.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Strategy</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Strategy</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coding-bike-shedding-real-work.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe Coding, Bike Shedding, and the Real Work</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/12/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/high-leverage-focus.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">High-Leverage Focus - Maximizing Impact</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/17/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/streamlit.html
+++ b/docs/tag/streamlit.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Streamlit</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Streamlit</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/proximity-analysis-with-streamlit.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Automating Proximity Analysis in Streamlit with Open Source Python</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">07/01/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/streamlit.html">Streamlit</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/spatial-analysis.html">Spatial-Analysis</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/systems-thinking.html
+++ b/docs/tag/systems-thinking.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Systems Thinking</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Systems Thinking</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/from-gis-projects-to-data-pipelines.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">From GIS Projects to Data Pipelines</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/29/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/data-engineering.html">Data Engineering</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/pipelines.html">Pipelines</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/careers.html">Careers</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/systems-thinking.html">Systems Thinking</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/teamwork.html
+++ b/docs/tag/teamwork.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Teamwork</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Teamwork</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/sharing-python-tools.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Sharing Python Tools - Practical Solutions and Considerations</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">08/20/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/programming.html">Programming</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/python.html">Python</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/teamwork.html">Teamwork</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/notebooks.html">Notebooks</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/technology.html
+++ b/docs/tag/technology.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Technology</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Technology</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/too-easy-to-start.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Too Easy to Start - AI Tools Shifted My Bottleneck from Building to Shipping</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">04/23/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/adapt-or-get-left-behind.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Adapt or Get Left Behind - The New AI Skillset</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/25/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/career.html">Career</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/gis-careers-ai-evolution.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">The Evolution of GIS Careers in the Age of Advanced AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/11/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/tools.html
+++ b/docs/tag/tools.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Tools</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Tools</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/numpad.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Creating a Virtual Numpad with AutoHotKey</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">10/09/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/tools.html">Tools</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/work.html
+++ b/docs/tag/work.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Work</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Work</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/removing-work-is-the-real-ai-leverage.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Removing Work Is the Real AI Leverage</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/11/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/vibe-coding-bike-shedding-real-work.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Vibe Coding, Bike Shedding, and the Real Work</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/12/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/gis-careers-ai-evolution.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">The Evolution of GIS Careers in the Age of Advanced AI</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">03/11/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/technology.html">Technology</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/high-leverage-focus.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">High-Leverage Focus - Maximizing Impact</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/17/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/strategy.html">Strategy</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/numpad.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Creating a Virtual Numpad with AutoHotKey</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">10/09/2024</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/tools.html">Tools</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/productivity.html">Productivity</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/workflow.html
+++ b/docs/tag/workflow.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Workflow</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Workflow</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/demystifying-agent-jargon.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">Demystifying Agent Jargon So You Can Actually Use This Stuff</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">02/17/2026</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/agents.html">Agents</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+    <div class="container bg-dark">
+      <a href="/post/how-the-blog-is-built.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">How the Blog Is Built</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">05/15/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/meta.html">Meta</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflow.html">Workflow</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/workflows.html
+++ b/docs/tag/workflows.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: Workflows</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: Workflows</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <div class="post-list bg-dark">
+    
+    <div class="container bg-dark">
+      <a href="/post/a-gis-analyst-from-the-future.html" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">A GIS Analyst From the Future</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">12/16/2025</span>
+                
+                <div class="post-tags bg-dark">
+                  
+                  <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/gis.html">GIS</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/workflows.html">Workflows</a>
+                  
+                  <a class="post-tag tag-link" href="/tag/automation.html">Automation</a>
+                  
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    
+  </div>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/docs/tag/x402.html
+++ b/docs/tag/x402.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
+    <title>Tag: X402</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/styles.css">
+
+    
+
+    <!-- Prism CSS (for code highlighting) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+
+    <!-- Prism JS (for code highlighting) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script> <!-- Add more languages as needed -->
+</head>
+<body class="bg-dark ">
+    
+    <header class="bg-dark py-3">
+        <div class="container bg-dark", id="header-container">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="/" class="home-link text-light"><h2>Danny McVey</h2></a>
+                <nav>
+                    <a href="/post/about-me.html" class="about-link btn btn-outline-light">About Me</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <main class="container my-4 ">
+        
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: X402</h1>
+    <p class="text-muted"><a class="tag-back-link" href="/">← Back to all posts</a></p>
+  </div>
+
+  
+  <p>No posts found for this tag.</p>
+  
+</div>
+
+    </main>
+
+    <footer class="bg-dark py-3">
+        <div class="container text-center text-light", id="footer-container">
+            <p>&copy; <span id="copyright-year"></span> Danny McVey. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <!-- Bootstrap JS and dependencies -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      (function(){
+        var el = document.getElementById('copyright-year');
+        if (el) el.textContent = new Date().getFullYear();
+      })();
+    </script>
+    
+</body>
+</html>

--- a/freeze.py
+++ b/freeze.py
@@ -1,5 +1,5 @@
 from flask_frozen import Freezer
-from app import app, POSTS_DIR
+from app import app, POSTS_DIR, UNPUBLISHED_TAGS, tag_slug
 import os
 
 # Publish the static site into /docs so GitHub Pages can serve it from the master branch.
@@ -20,6 +20,62 @@ def post():
     for filename in os.listdir(POSTS_DIR):
         if filename.endswith(".md"):
             yield {"post_name": filename[:-3]}
+
+
+@freezer.register_generator
+def tag():
+    """Freeze all tag pages."""
+    slugs = {}
+    for filename in os.listdir(POSTS_DIR):
+        if not filename.endswith(".md"):
+            continue
+
+        # Parse front matter cheaply
+        path = os.path.join(POSTS_DIR, filename)
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                content = f.read()
+        except OSError:
+            continue
+
+        tags = []
+        if content.startswith("---"):
+            try:
+                # tolerate CRLF/LF
+                normalized = content.replace("\r\n", "\n")
+                _, front_matter, _ = normalized.split("---\n", 2)
+                import yaml
+
+                meta = yaml.safe_load(front_matter) or {}
+                raw_tags = meta.get("tags", [])
+                # mirror app normalization behavior as close as possible
+                for t in raw_tags or []:
+                    if not isinstance(t, str):
+                        continue
+                    tt = t.title() if not t.isupper() else t
+                    tt = tt.replace("Arcgis Pro", "ArcGIS Pro").replace("Ai", "AI").replace("Gis", "GIS")
+                    tt = tt.strip()
+                    if tt:
+                        tags.append(tt)
+            except Exception:
+                tags = []
+
+        if any(t in UNPUBLISHED_TAGS for t in tags):
+            # unlisted posts don't get to create discoverable tag pages
+            continue
+
+        for t in tags:
+            if t in UNPUBLISHED_TAGS:
+                continue
+            slugs[tag_slug(t)] = True
+
+    # never publish tag pages for unpublished tags
+    for t in UNPUBLISHED_TAGS:
+        slugs.pop(tag_slug(t), None)
+
+    for s in sorted(slugs.keys()):
+        if s:
+            yield {"tag_slug_value": s}
 
 
 if __name__ == "__main__":

--- a/static/styles.css
+++ b/static/styles.css
@@ -187,11 +187,20 @@ pre code {
     font-size: 0.8em;
     margin-left: 5px;
     display: inline-block;
-    transition: background-color 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+a.post-tag {
+    text-decoration: none;
+}
+
+a.post-tag:hover {
+    text-decoration: none;
 }
 
 .post-tag:hover {
     background-color: #666;
+    color: #fff;
 }
 
 .post-card-link {

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,10 +23,10 @@ Danny McVey
             <h2 class="post-title text-light">{{ post.title }}</h2>
             <div class="post-meta bg-dark">
               <span class="post-date">{{ post.date.strftime('%m/%d/%Y') }}</span>
-              {% if post.tags %}
+              {% if post.tag_objs %}
               <div class="post-tags bg-dark">
-                {% for tag in post.tags %}
-                <span class="post-tag">{{ tag }}</span>
+                {% for tag in post.tag_objs %}
+                <a class="post-tag tag-link" href="{{ url_for('tag', tag_slug_value=tag.slug) }}">{{ tag.name }}</a>
                 {% endfor %}
               </div>
               {% endif %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -13,10 +13,10 @@
         <!-- Post content -->
         {{ content | safe }}
         <!-- Display the tags at the bottom -->
-        {% if tags %}
+        {% if tag_objs %}
         <p class="post-tags text-light">
-            {% for tag in tags %}
-                <span class="post-tag">{{ tag }}</span>{% if not loop.last %} {% endif %}
+            {% for tag in tag_objs %}
+                <a class="post-tag tag-link" href="{{ url_for('tag', tag_slug_value=tag.slug) }}">{{ tag.name }}</a>{% if not loop.last %} {% endif %}
             {% endfor %}
         </p>
         {% endif %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Tag: {{ tag_name }}{% endblock %}
+
+{% block content %}
+<div class="container bg-dark text-light">
+  <div class="tag-header">
+    <h1 class="text-light">Tag: {{ tag_name }}</h1>
+    <p class="text-muted"><a class="tag-back-link" href="{{ url_for('index') }}">← Back to all posts</a></p>
+  </div>
+
+  {% if posts %}
+  <div class="post-list bg-dark">
+    {% for post in posts %}
+    <div class="container bg-dark">
+      <a href="{{ url_for('post', post_name=post['name']) }}" class="post-card-link">
+        <div class="post-card card bg-dark">
+          <div class="card-body retro-text flicker bg-dark border">
+            <div class="post-header text-light">
+              <h2 class="post-title text-light">{{ post.title }}</h2>
+              <div class="post-meta bg-dark">
+                <span class="post-date">{{ post.date.strftime('%m/%d/%Y') }}</span>
+                {% if post.tag_objs %}
+                <div class="post-tags bg-dark">
+                  {% for tag in post.tag_objs %}
+                  <a class="post-tag tag-link" href="{{ url_for('tag', tag_slug_value=tag.slug) }}">{{ tag.name }}</a>
+                  {% endfor %}
+                </div>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>No posts found for this tag.</p>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## What
- Makes tags clickable on the homepage and on each post page
- Adds `/tag/<tag>.html` pages that list posts for a given tag
- Updates the freeze step so tag pages are generated into `docs/`

## Notes
- Unpublished tags (Stub/Draft/Unlisted) are not linked and do not get tag pages.
- Tag slugs are generated via a small `tag_slug()` helper (spaces -> hyphens, lowercase, etc.).

## Manual spot checks
- Homepage tag pills link to tag pages
- Post page tag pills link to tag pages
- Example tag page: `/tag/ai.html`
