### PR TITLE
freeze: ensure docs/.nojekyll is recreated

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -78,6 +78,23 @@ def tag():
             yield {"tag_slug_value": s}
 
 
+def _ensure_nojekyll():
+    """GitHub Pages uses Jekyll by default, which ignores directories starting with underscores.
+
+    This site depends on serving paths under /docs, so we force a .nojekyll file
+    to exist after freezing (the freeze step may wipe the destination).
+    """
+    dest = app.config.get("FREEZER_DESTINATION") or "docs"
+    try:
+        os.makedirs(dest, exist_ok=True)
+        with open(os.path.join(dest, ".nojekyll"), "w", encoding="utf-8") as f:
+            f.write("")
+    except OSError:
+        # Non-fatal; freezing succeeded but Pages might behave oddly.
+        pass
+
+
 if __name__ == "__main__":
     freezer.freeze()
+    _ensure_nojekyll()
 


### PR DESCRIPTION
Fixes the guardrail where Frozen-Flask wipes docs/ and deletes .nojekyll. After freezing, we now always recreate docs/.nojekyll so the site keeps serving correctly on GitHub Pages.