### PR TITLE
chore: update Python blog dependencies for security fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 blinker==1.8.2
 click==8.1.7
 colorama==0.4.6
-Flask==2.3.2
+Flask==3.1.3
 Flask-Markdown==0.3
 Frozen-Flask==1.0.2
 itsdangerous==2.2.0
 Jinja2==3.1.4
-Markdown==3.4.4
+Markdown==3.10.2
 MarkupSafe==2.1.5
 Pygments==2.15.1
 PyYAML==6.0.1
-Werkzeug==3.0.3
+Werkzeug==3.1.6


### PR DESCRIPTION
## Summary
- update Flask to 3.1.3
- update Werkzeug to 3.1.6
- update Markdown to 3.10.2

## Why
These bumps address currently open dependency alerts affecting the Python-rendered blog stack.

## Verification
- created a local virtualenv
- installed updated requirements
- imported `app.py` successfully
- ran `python freeze.py` successfully

## Notes
This PR intentionally avoids the experimental `astro/` subproject and keeps the blast radius small.