### PR TITLE
Refresh blog UI with blue GitHub-inspired styling

### DIFF
--- a/docs/post/2026-02-27-on-prem-mistral-gis-skill-pattern.html
+++ b/docs/post/2026-02-27-on-prem-mistral-gis-skill-pattern.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>A practical GIS skill pattern for on-prem Mistral (and other local LLMs)</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-03-01-trust-and-value-layers-in-agentic-engineering.html
+++ b/docs/post/2026-03-01-trust-and-value-layers-in-agentic-engineering.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Agentic Engineering</span>
+    </div>
+    
     <h1>Trust layers and value layers in agentic engineering</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-03-16-symphony-first-honest-vertical-slice.html
+++ b/docs/post/2026-03-16-symphony-first-honest-vertical-slice.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Symphony and the first honest vertical slice</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-03-23-inspectable-local-ai-orchestration.html
+++ b/docs/post/2026-03-23-inspectable-local-ai-orchestration.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>AI Orchestration Gets Real When You Can Inspect the Work</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-03-25-fixing-the-freeze-guardrail.html
+++ b/docs/post/2026-03-25-fixing-the-freeze-guardrail.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Blogging</span>
+    </div>
+    
     <h1>Fixing the freeze guardrail by admitting generated files are part of the product</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-03-25-from-system-validation-to-first-customers.html
+++ b/docs/post/2026-03-25-from-system-validation-to-first-customers.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>After the system works, the real job is finding the first customer</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-03-prompt-injection-isnt-what-you-think.html
+++ b/docs/post/2026-04-03-prompt-injection-isnt-what-you-think.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Prompt injection isn’t what you think</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-03-using-ai-inside-a-large-enterprise.html
+++ b/docs/post/2026-04-03-using-ai-inside-a-large-enterprise.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Trying to use AI inside a large enterprise without going numb</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-06-symphony-needs-evals-before-autonomy.html
+++ b/docs/post/2026-04-06-symphony-needs-evals-before-autonomy.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Symphony needs evals before autonomy</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-13-the-adapter-should-be-boring.html
+++ b/docs/post/2026-04-13-the-adapter-should-be-boring.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>The adapter should be boring</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-14-avoiding-the-dead-workplace.html
+++ b/docs/post/2026-04-14-avoiding-the-dead-workplace.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Avoiding the Dead Workplace: Keeping Human Ownership Alive in an AI-Heavy Workflow</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-15-define-success-before-the-system-does.html
+++ b/docs/post/2026-04-15-define-success-before-the-system-does.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Define Success Before the System Does</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-20-drafts-are-how-ideas-become-systems.html
+++ b/docs/post/2026-04-20-drafts-are-how-ideas-become-systems.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Drafts Are How Ideas Become Systems</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-24-from-prompt-to-production-making-ai-generated-code-actually-usable.html
+++ b/docs/post/2026-04-24-from-prompt-to-production-making-ai-generated-code-actually-usable.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>From Prompt to Production: Making AI-Generated Code Actually Usable</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-24-i-let-an-ai-write-my-gis-workflow-heres-what-broke.html
+++ b/docs/post/2026-04-24-i-let-an-ai-write-my-gis-workflow-heres-what-broke.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>I Let an AI Write My GIS Workflow. Here&#39;s What Broke.</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-04-27-ai-needs-real-work.html
+++ b/docs/post/2026-04-27-ai-needs-real-work.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>AI Needs Real Work</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-05-04-spatial-workbench-layer-ux-pass.html
+++ b/docs/post/2026-05-04-spatial-workbench-layer-ux-pass.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Spatial Workbench Needed a Layer UX Pass Before Anything Smarter</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-05-11-inspectable-tools-need-clear-modes.html
+++ b/docs/post/2026-05-11-inspectable-tools-need-clear-modes.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Inspectable Tools Still Need Clear Modes</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-05-17-interview-prep-deserves-a-better-interface.html
+++ b/docs/post/2026-05-17-interview-prep-deserves-a-better-interface.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Interview Prep Deserves a Better Interface</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-05-25-version-control-reduces-risk.html
+++ b/docs/post/2026-05-25-version-control-reduces-risk.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Github</span>
+    </div>
+    
     <h1>Version Control Reduces Risk</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-01-spatial-tools-need-a-better-boundary.html
+++ b/docs/post/2026-06-01-spatial-tools-need-a-better-boundary.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Spatial Tools Need a Better Boundary</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-02-curves-in-gis-everywhere-and-barely-supported.html
+++ b/docs/post/2026-06-02-curves-in-gis-everywhere-and-barely-supported.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Curves in GIS: Everywhere and Barely Supported</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-05-what-scout-means-for-my-work-next-year.html
+++ b/docs/post/2026-06-05-what-scout-means-for-my-work-next-year.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Why Systems Like Scout Matter for the Kind of Software I Want to Build</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-08-mission-systems-need-receipts.html
+++ b/docs/post/2026-06-08-mission-systems-need-receipts.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Mission Systems Need Receipts</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-11-map-capsules-and-scrollytelling.html
+++ b/docs/post/2026-06-11-map-capsules-and-scrollytelling.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Map capsules and scrollytelling for GIS workflow writeups</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-11-rich-formatting-demo.html
+++ b/docs/post/2026-06-11-rich-formatting-demo.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Meta</span>
+    </div>
+    
     <h1>Rich Formatting Demo</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-15-honest-intermediate-states.html
+++ b/docs/post/2026-06-15-honest-intermediate-states.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Honest Intermediate States Make Better Systems</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-17-github-copilot-teaches-git-by-guiding-decisions.html
+++ b/docs/post/2026-06-17-github-copilot-teaches-git-by-guiding-decisions.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>GitHub Copilot Teaches Git by Guiding Decisions</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-22-a-deployment-is-not-done-until-the-system-changes.html
+++ b/docs/post/2026-06-22-a-deployment-is-not-done-until-the-system-changes.html
@@ -20,13 +20,14 @@
     crossorigin=""
 >
 <link rel="stylesheet" href="/static/map-embed.css">
+<link rel="stylesheet" href="/static/post-reading.css">
 
 
     <!-- Prism CSS (for code highlighting) -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -39,7 +40,7 @@
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <style>
     pre { line-height: 125%; }
@@ -126,12 +127,18 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 .codehilite .vm { color: #f8f8f2 } /* Name.Variable.Magic */
 .codehilite .il { color: #ae81ff } /* Literal.Number.Integer.Long */
 </style>
-<div class="container bg-dark text-light">
-    <article>
-        
-        <h1 class="text-light">A Deployment Is Not Done Until the Running System Changes</h1>
-        <!-- Post content -->
-        <p><img src="/static/images/deployment-runtime-truth-hero.png" alt="Editorial illustration of a split operations room where successful build signals contrast with a live system still serving the old state" style="width:100%; display:block; margin: 12px 0 18px 0; border-radius: 12px;" /></p>
+<header class="post-hero post-hero-legacy">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Systems</span>
+    </div>
+    
+    <h1>A Deployment Is Not Done Until the Running System Changes</h1>
+</header>
+
+<article class="post-reading post-reading-legacy">
+    <p><img src="/static/images/deployment-runtime-truth-hero.png" alt="Editorial illustration of a split operations room where successful build signals contrast with a live system still serving the old state" style="width:100%; display:block; margin: 12px 0 18px 0; border-radius: 12px;" /></p>
 <p>This week I spent some time getting <code>resume-tailor</code> into a more real state on my homelab.</p>
 <p>That included Docker deployment work, wiring the web app to the API cleanly, getting assisted tailoring working with a server-side model key, and restoring <code>.docx</code> and PDF export behavior after it broke.</p>
 <p>The technical details were specific.<br />
@@ -264,22 +271,21 @@ Built is not deployed.<br />
 Restarted is not deployed.</p>
 <p>Changed behavior, verified live, with evidence:<br />
 that is deployed.</p>
-        <!-- Display the tags at the bottom -->
-        
-        <p class="post-tags text-light">
-            
-                <a class="post-tag tag-link" href="/tag/systems.html">Systems</a> 
-            
-                <a class="post-tag tag-link" href="/tag/deployment.html">Deployment</a> 
-            
-                <a class="post-tag tag-link" href="/tag/ai.html">AI</a> 
-            
-                <a class="post-tag tag-link" href="/tag/work.html">Work</a>
-            
-        </p>
-        
-    </article>
-</div>
+</article>
+
+
+<footer class="post-tags-footer">
+    
+        <a class="post-tag tag-link" href="/tag/systems.html">Systems</a>
+    
+        <a class="post-tag tag-link" href="/tag/deployment.html">Deployment</a>
+    
+        <a class="post-tag tag-link" href="/tag/ai.html">AI</a>
+    
+        <a class="post-tag tag-link" href="/tag/work.html">Work</a>
+    
+</footer>
+
 
 <script src="/static/copy-code.js"></script>
 

--- a/docs/post/2026-06-22-scheduled-task-or-agent-automation.html
+++ b/docs/post/2026-06-22-scheduled-task-or-agent-automation.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>How I Decide Between a Scheduled Task and an Agent</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-06-29-a-writing-workflow-is-not-real-until-it-leaves-a-draft.html
+++ b/docs/post/2026-06-29-a-writing-workflow-is-not-real-until-it-leaves-a-draft.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Writing</span>
+    </div>
+    
     <h1>A Writing Workflow Is Not Real Until It Leaves a Draft</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-07-13-the-input-path-is-part-of-the-system.html
+++ b/docs/post/2026-07-13-the-input-path-is-part-of-the-system.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Systems</span>
+    </div>
+    
     <h1>The Input Path Is Part of the System</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/2026-07-15-version-control-is-a-safety-practice.html
+++ b/docs/post/2026-07-15-version-control-is-a-safety-practice.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Github</span>
+    </div>
+    
     <h1>Version Control Is a Safety Practice</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/Empowering-GIS-With-AI.html
+++ b/docs/post/Empowering-GIS-With-AI.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Empowering Geospatial Workflows with Generative AI</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/a-gis-analyst-from-the-future.html
+++ b/docs/post/a-gis-analyst-from-the-future.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>A GIS Analyst From the Future</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/about-me.html
+++ b/docs/post/about-me.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Personal</span>
+    </div>
+    
     <h1>About me</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/adapt-or-get-left-behind.html
+++ b/docs/post/adapt-or-get-left-behind.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Adapt or Get Left Behind - The New AI Skillset</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/agents-skills-tools-how-to-decide.html
+++ b/docs/post/agents-skills-tools-how-to-decide.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Agent vs Skill vs Deterministic Tool: a practical decision guide</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/ai-gp-tools.html
+++ b/docs/post/ai-gp-tools.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>AI enhanced GP tools in ArcGIS Pro</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/arcpy-tool-alternatives.html
+++ b/docs/post/arcpy-tool-alternatives.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Open source alternatives to ArcPy</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/choosing-the-right-ai-model-for-the-right-gis-job.html
+++ b/docs/post/choosing-the-right-ai-model-for-the-right-gis-job.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Choosing the Right AI Model for the Right GIS Job</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/damn field maps.html
+++ b/docs/post/damn field maps.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Python</span>
+    </div>
+    
     <h1>Field Mapping Frustrations in GIS - Automating Spatial Joins</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/demystifying-agent-jargon.html
+++ b/docs/post/demystifying-agent-jargon.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Demystifying Agent Jargon So You Can Actually Use This Stuff</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/everything-is-software.html
+++ b/docs/post/everything-is-software.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
     <h1>Everything Is Software</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/from-gis-projects-to-data-pipelines.html
+++ b/docs/post/from-gis-projects-to-data-pipelines.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>From GIS Projects to Data Pipelines</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/gis-careers-ai-evolution.html
+++ b/docs/post/gis-careers-ai-evolution.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>The Evolution of GIS Careers in the Age of Advanced AI</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/gis-models-01-when-good-enough-fails.html
+++ b/docs/post/gis-models-01-when-good-enough-fails.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>When &#34;Good Enough&#34; Fails</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/gis-models-02-gis-is-a-domain-not-just-python.html
+++ b/docs/post/gis-models-02-gis-is-a-domain-not-just-python.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>GIS Is a Domain, Not Just Python</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/gis-models-03-agents-scripts-and-the-cost-of-autonomy.html
+++ b/docs/post/gis-models-03-agents-scripts-and-the-cost-of-autonomy.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Agents, Scripts, and the Cost of Autonomy</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/gis-models-04-model-selection-matrix-for-gis.html
+++ b/docs/post/gis-models-04-model-selection-matrix-for-gis.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>A Practical Model Selection Matrix for GIS</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/high-leverage-focus.html
+++ b/docs/post/high-leverage-focus.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Productivity</span>
+    </div>
+    
     <h1>High-Leverage Focus - Maximizing Impact</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/how-the-blog-is-built.html
+++ b/docs/post/how-the-blog-is-built.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Meta</span>
+    </div>
+    
     <h1>How the Blog Is Built</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/memory-considerations-spatial-data.html
+++ b/docs/post/memory-considerations-spatial-data.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Data</span>
+    </div>
+    
     <h1>Considerations for Spatial Data That Doesn&#39;t Fit in Memory</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/numpad.html
+++ b/docs/post/numpad.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Tools</span>
+    </div>
+    
     <h1>Creating a Virtual Numpad with AutoHotKey</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/prioritizing-health.html
+++ b/docs/post/prioritizing-health.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Health</span>
+    </div>
+    
     <h1>Prioritizing Health as a Knowledge Worker</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/problems-to-solve.html
+++ b/docs/post/problems-to-solve.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Work</span>
+    </div>
+    
     <h1>Solving the right problems</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/proximity-analysis-with-streamlit.html
+++ b/docs/post/proximity-analysis-with-streamlit.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Automating Proximity Analysis in Streamlit with Open Source Python</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/purpose-driven-process.html
+++ b/docs/post/purpose-driven-process.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Productivity</span>
+    </div>
+    
     <h1>Purpose-Driven Process</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/removing-work-is-the-real-ai-leverage.html
+++ b/docs/post/removing-work-is-the-real-ai-leverage.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Removing Work Is the Real AI Leverage</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/sharing-python-tools.html
+++ b/docs/post/sharing-python-tools.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Programming</span>
+    </div>
+    
     <h1>Sharing Python Tools - Practical Solutions and Considerations</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/spatial-index.html
+++ b/docs/post/spatial-index.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>What is a Spatial Index and Why Should I Care?</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/spatial-workbench-ecosystem.html
+++ b/docs/post/spatial-workbench-ecosystem.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">GIS</span>
+    </div>
+    
     <h1>Toward a Spatial Workbench Ecosystem</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/teaching-python.html
+++ b/docs/post/teaching-python.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Programming</span>
+    </div>
+    
     <h1>Thinking like a programmer</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/too-easy-to-start.html
+++ b/docs/post/too-easy-to-start.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Too Easy to Start - AI Tools Shifted My Bottleneck from Building to Shipping</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/vector-dbs.html
+++ b/docs/post/vector-dbs.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">Programming</span>
+    </div>
+    
     <h1>What are Vector Databases?</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/vibe-coded-camreview.html
+++ b/docs/post/vibe-coded-camreview.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Vibe coding CamReview: a trail cam app I actually use</h1>
     <div class="post-meta-bar">
         

--- a/docs/post/vibe-coding-bike-shedding-real-work.html
+++ b/docs/post/vibe-coding-bike-shedding-real-work.html
@@ -103,7 +103,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
 
 </head>
-<body class="bg-dark ">
+<body class="bg-dark post-page">
     
     <header class="bg-dark py-3">
         <div class="container bg-dark", id="header-container">
@@ -116,13 +116,19 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
         </div>
     </header>
 
-    <main class="container my-4 ">
+    <main class="container my-4 post-main">
         
 <!-- Scroll progress indicator -->
 <div class="scroll-progress"></div>
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="/" class="post-back-link">Back to blog</a>
+    
+    <div class="post-kicker-row">
+        <span class="post-kicker">AI</span>
+    </div>
+    
     <h1>Vibe Coding, Bike Shedding, and the Real Work</h1>
     <div class="post-meta-bar">
         

--- a/docs/static/post-reading.css
+++ b/docs/static/post-reading.css
@@ -155,7 +155,7 @@
 .post-reading img {
     max-width: 100%;
     height: auto;
-    border-radius: 0;
+    border-radius: 0 !important;
     margin: 2em 0;
     display: block;
 }
@@ -169,7 +169,7 @@
     width: calc(100% + 4rem);
     max-width: calc(100% + 4rem);
     margin: 0;
-    border-radius: 0;
+    border-radius: 0 !important;
 }
 
 .post-reading figcaption {

--- a/docs/static/post-reading.css
+++ b/docs/static/post-reading.css
@@ -16,7 +16,7 @@
     padding: 2rem 1.5rem 4rem;
     line-height: 1.8;
     font-size: 1.125rem;
-    color: #e8e6e3;
+    color: #dce6f6;
 }
 
 /* --- Typography --- */
@@ -27,7 +27,7 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-weight: 700;
     letter-spacing: -0.02em;
-    color: #ffffff;
+    color: #f6f9ff;
     margin-top: 2.5em;
     margin-bottom: 0.6em;
     line-height: 1.25;
@@ -52,7 +52,7 @@
 .post-reading p,
 .post-reading li {
     font-family: Georgia, 'Times New Roman', serif;
-    color: #d4d0cb;
+    color: #d4ddef;
 }
 
 .post-reading p {
@@ -60,15 +60,15 @@
 }
 
 .post-reading a {
-    color: #6cb4ee;
+    color: #8fc9ff;
     text-decoration: underline;
-    text-decoration-color: rgba(108, 180, 238, 0.3);
+    text-decoration-color: rgba(143, 201, 255, 0.34);
     text-underline-offset: 3px;
     transition: text-decoration-color 0.2s;
 }
 
 .post-reading a:hover {
-    text-decoration-color: rgba(108, 180, 238, 0.8);
+    text-decoration-color: rgba(143, 201, 255, 0.9);
 }
 
 .post-reading strong {
@@ -93,18 +93,18 @@
 }
 
 .post-reading li::marker {
-    color: #6cb4ee;
+    color: #8fc9ff;
 }
 
 /* --- Blockquotes / Pull quotes --- */
 .post-reading blockquote {
-    border-left: 3px solid #6cb4ee;
-    background: rgba(108, 180, 238, 0.05);
+    border-left: 3px solid #8fc9ff;
+    background: rgba(143, 201, 255, 0.06);
     padding: 1.25em 1.5em;
     margin: 2em 0;
     border-radius: 0 8px 8px 0;
     font-style: italic;
-    color: #b8b4af;
+    color: #c3d2e7;
 }
 
 .post-reading blockquote p {
@@ -119,7 +119,7 @@
 .post-reading blockquote strong {
     font-style: normal;
     font-size: 1.15em;
-    color: #e8e6e3;
+    color: #ecf3ff;
     display: block;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.4;
@@ -136,8 +136,8 @@
 }
 
 .post-reading .callout-info {
-    border-left: 4px solid #6cb4ee;
-    background: rgba(108, 180, 238, 0.04);
+    border-left: 4px solid #8fc9ff;
+    background: rgba(143, 201, 255, 0.05);
 }
 
 .post-reading .callout-warning {
@@ -146,8 +146,8 @@
 }
 
 .post-reading .callout-success {
-    border-left: 4px solid #4caf7d;
-    background: rgba(76, 175, 125, 0.04);
+    border-left: 4px solid #6fb8ff;
+    background: rgba(111, 184, 255, 0.05);
 }
 
 /* --- Figures & images --- */
@@ -187,7 +187,7 @@
     background: rgba(255, 255, 255, 0.06);
     padding: 0.2em 0.4em;
     border-radius: 4px;
-    color: #e0ddd8;
+    color: #e7eefc;
 }
 
 .post-reading pre {
@@ -263,7 +263,7 @@
 }
 
 .post-reading sup a {
-    color: #6cb4ee;
+    color: #8fc9ff;
     text-decoration: none;
     font-weight: 600;
 }
@@ -271,46 +271,97 @@
 /* --- Post header --- */
 .post-hero {
     max-width: 680px;
-    margin: 0 auto 0.95rem;
-    padding: 1.1rem 1.15rem 1.2rem;
-    border-radius: 3px;
-    border: 1px solid rgba(255, 255, 255, 0.09);
-    background: rgba(8, 13, 22, 0.9);
+    margin: 0 auto 1rem;
+    padding: 1.15rem 1.15rem 1.5rem;
+    border-radius: 28px;
+    border: 1px solid rgba(136, 188, 255, 0.18);
+    background:
+        linear-gradient(180deg, rgba(9, 18, 33, 0.96), rgba(4, 9, 17, 0.98));
+    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+    text-align: center;
 }
 
 .post-hero h1 {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-size: clamp(1.45rem, 3.5vw, 2rem);
+    font-size: clamp(2rem, 4.8vw, 3.55rem);
     font-weight: 760;
-    letter-spacing: -0.015em;
-    line-height: 1.24;
+    letter-spacing: -0.05em;
+    line-height: 1.03;
     color: #f2f7ff;
     margin: 0;
+    text-wrap: balance;
+}
+
+.post-back-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1.6rem;
+    color: #cad6e8;
+    text-decoration: none;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+.post-back-link::before {
+    content: "←";
+    margin-right: 0.7rem;
+    font-size: 1rem;
+}
+
+.post-back-link:hover {
+    color: #ffffff;
+    text-decoration: none;
+}
+
+.post-kicker-row {
+    margin-bottom: 0.95rem;
+}
+
+.post-kicker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.38rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid rgba(143, 201, 255, 0.2);
+    background: rgba(111, 184, 255, 0.12);
+    color: #d4eaff;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
 .post-meta-bar {
     display: flex;
     align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
     gap: 0.65em;
-    margin-top: 0.58rem;
+    margin-top: 1rem;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-size: 0.8rem;
-    color: #89bde2;
-    letter-spacing: 0.045em;
+    font-size: 0.78rem;
+    color: #99adc8;
+    letter-spacing: 0.16em;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
     text-transform: uppercase;
     font-weight: 600;
 }
 
 .post-meta-bar time {
-    color: #89bde2;
+    color: #99adc8;
 }
 
 .post-meta-bar .reading-time {
-    color: #89bde2;
+    color: #99adc8;
 }
 
 .post-meta-bar .separator {
-    color: rgba(137, 189, 226, 0.85);
+    color: rgba(153, 173, 200, 0.85);
 }
 
 /* --- Scroll progress bar --- */
@@ -319,7 +370,7 @@
     top: 0;
     left: 0;
     height: 3px;
-    background: linear-gradient(to right, #6cb4ee, #a78bfa);
+    background: linear-gradient(to right, #77b9ff, #c8e4ff);
     width: 0%;
     z-index: 9999;
     transition: width 0.1s linear;
@@ -333,9 +384,9 @@
 }
 
 .post-toc details {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 8px;
+    background: rgba(7, 13, 24, 0.82);
+    border: 1px solid rgba(136, 188, 255, 0.12);
+    border-radius: 18px;
     padding: 1em 1.25em;
     margin-bottom: 0.75em;
 }
@@ -348,7 +399,7 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 0.85rem;
     font-weight: 600;
-    color: #999;
+    color: #99adc8;
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -390,7 +441,7 @@
 }
 
 .post-toc a:hover {
-    color: #6cb4ee;
+    color: #8fc9ff;
 }
 
 .post-toc .toc-h3 {
@@ -402,34 +453,36 @@
     max-width: 680px;
     margin: 0 auto;
     padding: 2rem 1.5rem 3rem;
-    border-top: 1px solid rgba(255,255,255,0.06);
+    border-top: 1px solid rgba(136, 188, 255, 0.1);
 }
 
 .post-tags-footer .post-tag {
-    background: rgba(255,255,255,0.05);
-    border: 1px solid rgba(255,255,255,0.08);
-    color: #aaa;
+    background: rgba(9, 17, 31, 0.84);
+    border: 1px solid rgba(136, 188, 255, 0.16);
+    color: #a6d5ff;
     padding: 0.4em 0.8em;
-    border-radius: 6px;
-    font-size: 0.8rem;
+    border-radius: 999px;
+    font-size: 0.74rem;
     margin-right: 0.5em;
     margin-bottom: 0.5em;
     display: inline-block;
     transition: all 0.2s;
     text-decoration: none;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .post-tags-footer .post-tag:hover {
-    background: rgba(108, 180, 238, 0.1);
-    border-color: rgba(108, 180, 238, 0.3);
-    color: #6cb4ee;
+    background: rgba(119, 185, 255, 0.12);
+    border-color: rgba(166, 213, 255, 0.34);
+    color: #eff7ff;
 }
 
 /* --- Responsive --- */
 @media (max-width: 720px) {
     .post-hero h1 {
-        font-size: clamp(1.25rem, 7vw, 1.6rem);
+        font-size: clamp(1.7rem, 9vw, 2.35rem);
     }
     
     .post-reading {
@@ -463,8 +516,14 @@
 
     .post-hero {
         margin-bottom: 0.8rem;
-        padding-top: 0.95rem;
-        padding-bottom: 1rem;
+        padding-top: 1rem;
+        padding-bottom: 1.2rem;
+        border-radius: 22px;
+    }
+
+    .post-back-link {
+        margin-bottom: 1.2rem;
+        font-size: 0.73rem;
     }
 }
 

--- a/docs/static/post-reading.css
+++ b/docs/static/post-reading.css
@@ -102,7 +102,7 @@
     background: rgba(143, 201, 255, 0.06);
     padding: 1.25em 1.5em;
     margin: 2em 0;
-    border-radius: 0 8px 8px 0;
+    border-radius: 0;
     font-style: italic;
     color: #c3d2e7;
 }
@@ -129,8 +129,9 @@
 /* Use in markdown: <div class="callout"> ... </div> */
 .post-reading .callout {
     background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 12px;
+    border: 0;
+    border-left: 3px solid rgba(143, 201, 255, 0.45);
+    border-radius: 0;
     padding: 1.5em 1.75em;
     margin: 2em 0;
 }
@@ -154,7 +155,7 @@
 .post-reading img {
     max-width: 100%;
     height: auto;
-    border-radius: 8px;
+    border-radius: 0;
     margin: 2em 0;
     display: block;
 }
@@ -168,7 +169,7 @@
     width: calc(100% + 4rem);
     max-width: calc(100% + 4rem);
     margin: 0;
-    border-radius: 8px;
+    border-radius: 0;
 }
 
 .post-reading figcaption {
@@ -186,19 +187,19 @@
     font-size: 0.85em;
     background: rgba(255, 255, 255, 0.06);
     padding: 0.2em 0.4em;
-    border-radius: 4px;
+    border-radius: 2px;
     color: #e7eefc;
 }
 
 .post-reading pre {
     margin: 2em -1rem;
     padding: 1.25em 1.5em;
-    border-radius: 8px;
+    border-radius: 0;
     overflow-x: auto;
     font-size: 0.875rem;
     line-height: 1.6;
     background: #111 !important;
-    border: 1px solid rgba(255,255,255,0.06);
+    border: 0;
 }
 
 .post-reading pre code {
@@ -240,7 +241,7 @@
 .post-reading hr {
     border: none;
     height: 1px;
-    background: linear-gradient(to right, transparent, rgba(255,255,255,0.12), transparent);
+    background: rgba(255,255,255,0.12);
     margin: 3em 0;
 }
 
@@ -273,11 +274,10 @@
     max-width: 680px;
     margin: 0 auto 1rem;
     padding: 1.15rem 1.15rem 1.5rem;
-    border-radius: 28px;
-    border: 1px solid rgba(136, 188, 255, 0.18);
-    background:
-        linear-gradient(180deg, rgba(9, 18, 33, 0.96), rgba(4, 9, 17, 0.98));
-    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+    border-radius: 0;
+    border: 0;
+    background: #06101c;
+    box-shadow: none;
     text-align: center;
 }
 
@@ -325,9 +325,9 @@
     align-items: center;
     justify-content: center;
     padding: 0.38rem 0.8rem;
-    border-radius: 999px;
-    border: 1px solid rgba(143, 201, 255, 0.2);
-    background: rgba(111, 184, 255, 0.12);
+    border-radius: 2px;
+    border: 0;
+    background: #0b1726;
     color: #d4eaff;
     font-size: 0.72rem;
     font-weight: 700;
@@ -370,7 +370,7 @@
     top: 0;
     left: 0;
     height: 3px;
-    background: linear-gradient(to right, #77b9ff, #c8e4ff);
+    background: #77b9ff;
     width: 0%;
     z-index: 9999;
     transition: width 0.1s linear;
@@ -384,9 +384,9 @@
 }
 
 .post-toc details {
-    background: rgba(7, 13, 24, 0.82);
-    border: 1px solid rgba(136, 188, 255, 0.12);
-    border-radius: 18px;
+    background: #06101c;
+    border: 0;
+    border-radius: 0;
     padding: 1em 1.25em;
     margin-bottom: 0.75em;
 }
@@ -457,11 +457,11 @@
 }
 
 .post-tags-footer .post-tag {
-    background: rgba(9, 17, 31, 0.84);
-    border: 1px solid rgba(136, 188, 255, 0.16);
+    background: #0b1726;
+    border: 0;
     color: #a6d5ff;
     padding: 0.4em 0.8em;
-    border-radius: 999px;
+    border-radius: 2px;
     font-size: 0.74rem;
     margin-right: 0.5em;
     margin-bottom: 0.5em;
@@ -475,7 +475,6 @@
 
 .post-tags-footer .post-tag:hover {
     background: rgba(119, 185, 255, 0.12);
-    border-color: rgba(166, 213, 255, 0.34);
     color: #eff7ff;
 }
 
@@ -518,7 +517,7 @@
         margin-bottom: 0.8rem;
         padding-top: 1rem;
         padding-bottom: 1.2rem;
-        border-radius: 22px;
+        border-radius: 0;
     }
 
     .post-back-link {

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -3,11 +3,39 @@ html {
     overflow-y: scroll;
 }
 
+:root {
+    --page-bg: #02060d;
+    --page-bg-soft: #08111e;
+    --panel-bg: rgba(6, 12, 22, 0.9);
+    --panel-bg-strong: rgba(4, 9, 17, 0.96);
+    --panel-border: rgba(136, 188, 255, 0.16);
+    --panel-border-strong: rgba(136, 188, 255, 0.28);
+    --text-primary: #f4f8ff;
+    --text-muted: #99adc8;
+    --text-soft: #cad6e8;
+    --accent: #77b9ff;
+    --accent-strong: #a6d5ff;
+    --accent-wash: rgba(119, 185, 255, 0.12);
+    --surface-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+}
+
+body {
+    background:
+        radial-gradient(circle at top center, rgba(62, 118, 196, 0.2), transparent 34%),
+        linear-gradient(180deg, #02050b 0%, #040912 48%, #02060d 100%);
+    color: var(--text-primary);
+}
+
 body.home {
     position: relative;
     min-height: 100vh;
     overflow-x: hidden;
-    background-color: #000;
+}
+
+body.home,
+body.tag-page,
+body.post-page {
+    background-color: var(--page-bg);
 }
 
 body.home main.home-main {
@@ -40,7 +68,7 @@ body.home main.home-main {
 
 
 blockquote {
-    border-left: 4px solid #569cd6;
+    border-left: 4px solid var(--accent);
     padding-left: 1em;
     color: #bbbbbb;
     font-style: italic;
@@ -121,18 +149,19 @@ pre code {
 .post-tags {
     margin-bottom: 0em;
     font-size: 0.9em;
-    color: #ff0000;
+    color: var(--text-soft);
 }
 
 .post-tag {
-    background-color: #1c1c1c;
-    color: #ddd;
+    background-color: rgba(10, 18, 32, 0.92);
+    color: var(--accent-strong);
     padding: 5px 8px;
-    border-radius: 4px;
+    border-radius: 999px;
     font-size: 0.8em;
     margin-left: 5px;
     display: inline-block;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    border: 1px solid var(--panel-border);
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 a.post-tag {
@@ -144,7 +173,8 @@ a.post-tag:hover {
 }
 
 .post-tag:hover {
-    background-color: #666;
+    background-color: var(--accent-wash);
+    border-color: var(--panel-border-strong);
     color: #fff;
 }
 
@@ -177,16 +207,19 @@ th {
 
 
 #footer-container, #header-container {
-    background-color: #1c1c1c !important;
+    background-color: rgba(6, 11, 20, 0.82) !important;
     padding: 1em;
-    border-radius: 10px;
+    border-radius: 18px;
+    border: 1px solid var(--panel-border);
+    box-shadow: var(--surface-shadow);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
 }
 
 
 /* Override the bg-dark class to make it black */
 .bg-dark {
-    background-color: #000 !important;
-    
+    background-color: transparent !important;
 }
 
 hr {
@@ -196,94 +229,111 @@ hr {
 /* Homepage facelift inspired by the rich post reading look */
 body.home,
 body.tag-page {
-    background-color: #07090d;
+    background-color: var(--page-bg);
 }
 
 body.home #header-container,
 body.home #footer-container,
+body.post-page #header-container,
+body.post-page #footer-container,
 body.tag-page #header-container,
 body.tag-page #footer-container {
-    background: rgba(7, 10, 16, 0.92) !important;
-    border: 1px solid rgba(255, 255, 255, 0.09);
-    box-shadow: none;
-    -webkit-backdrop-filter: blur(8px);
-    backdrop-filter: blur(8px);
+    background:
+        linear-gradient(180deg, rgba(8, 15, 28, 0.95), rgba(4, 9, 17, 0.94)) !important;
 }
 
 body.home .home-link,
 body.home .home-link:hover,
+body.post-page .home-link,
+body.post-page .home-link:hover,
 body.tag-page .home-link,
 body.tag-page .home-link:hover {
     text-decoration: none;
 }
 
 body.home .home-link h2,
+body.post-page .home-link h2,
 body.tag-page .home-link h2 {
     margin: 0;
-    font-size: 1.35rem;
+    font-size: 1.1rem;
     font-weight: 700;
-    letter-spacing: 0.02em;
-    color: #f5f8ff;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--text-primary);
 }
 
 body.home .about-link,
+body.post-page .about-link,
 body.tag-page .about-link {
-    border-color: rgba(120, 190, 255, 0.55);
-    color: #d9edff;
-    background: rgba(108, 180, 238, 0.08);
+    border-color: var(--panel-border-strong);
+    color: var(--accent-strong);
+    background: rgba(9, 18, 34, 0.78);
+    border-radius: 999px;
+    padding: 0.45rem 0.95rem;
+    font-size: 0.76rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 body.home .about-link:hover,
+body.post-page .about-link:hover,
 body.tag-page .about-link:hover {
-    background: rgba(108, 180, 238, 0.2);
-    border-color: rgba(160, 220, 255, 0.8);
+    background: var(--accent-wash);
+    border-color: rgba(166, 213, 255, 0.74);
     color: #ffffff;
 }
 
 body.home main.home-main,
-body.tag-page main.home-main {
-    max-width: 880px;
+body.tag-page main.home-main,
+body.post-page main.post-main {
+    max-width: 960px;
     margin: 1.25rem auto 2rem;
-    padding: 0 0.75rem;
+    padding: 0 0.85rem;
 }
 
 .tag-page-lead {
-    margin: 0 auto 1rem;
-    padding: 1rem 0.1rem 0.35rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    margin: 0 auto 1.2rem;
+    padding: 1.5rem 1.25rem 1.25rem;
+    border: 1px solid var(--panel-border);
+    border-radius: 28px;
+    background:
+        linear-gradient(180deg, rgba(9, 18, 33, 0.95), rgba(5, 10, 18, 0.96));
+    box-shadow: var(--surface-shadow);
 }
 
 .tag-page-kicker {
     margin: 0;
-    color: #8bc8ff;
-    font-size: 0.78rem;
+    color: var(--accent);
+    font-size: 0.74rem;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.18em;
     font-weight: 650;
 }
 
 .tag-page-title {
     margin: 0.25rem 0 0;
-    color: #f7fbff;
-    font-size: clamp(1.35rem, 3.4vw, 1.9rem);
-    line-height: 1.2;
+    color: var(--text-primary);
+    font-size: clamp(1.6rem, 4vw, 2.35rem);
+    line-height: 1.08;
     font-weight: 760;
+    max-width: 12ch;
 }
 
 .tag-page-backline {
-    margin: 0.45rem 0 0;
+    margin: 0.75rem 0 0;
 }
 
 .tag-back-link {
-    color: #b9daf5;
+    color: var(--text-soft);
     text-decoration: none;
-    border-bottom: 1px solid rgba(185, 218, 245, 0.4);
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
 }
 
 .tag-back-link:hover {
     color: #e3f1ff;
     text-decoration: none;
-    border-bottom-color: rgba(227, 241, 255, 0.7);
 }
 
 .tag-empty-state {
@@ -293,91 +343,107 @@ body.tag-page main.home-main {
 
 .home-feed {
     display: grid;
-    gap: 0.95rem;
+    gap: 1.15rem;
 }
 
 .home-post-card {
     position: relative;
-    padding: 1.1rem 1.15rem 1.2rem;
-    border-radius: 3px;
-    border: 1px solid rgba(255, 255, 255, 0.09);
-    background: rgba(8, 13, 22, 0.9);
-    box-shadow: none;
-    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    padding: 1.5rem 1.45rem 1.5rem;
+    border-radius: 28px;
+    border: 1px solid var(--panel-border);
+    background:
+        linear-gradient(180deg, rgba(8, 16, 29, 0.96), rgba(4, 10, 18, 0.98));
+    box-shadow: var(--surface-shadow);
+    overflow: hidden;
+    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.home-post-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(143, 201, 255, 0.55), transparent);
+    opacity: 0.8;
 }
 
 .home-post-card:hover {
-    transform: none;
-    border-color: rgba(130, 196, 255, 0.3);
-    box-shadow: none;
+    transform: translateY(-2px);
+    border-color: var(--panel-border-strong);
+    background:
+        linear-gradient(180deg, rgba(10, 21, 38, 0.98), rgba(5, 11, 21, 0.99));
 }
 
 .home-post-topline {
-    margin: 0 0 0.35rem;
+    margin: 0 0 0.85rem;
 }
 
 .home-post-date {
-    color: #89bde2;
-    font-size: 0.82rem;
+    color: var(--text-muted);
+    font-size: 0.78rem;
     font-weight: 600;
-    letter-spacing: 0.045em;
+    letter-spacing: 0.16em;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
     text-transform: uppercase;
 }
 
 .home-post-title {
     margin: 0;
-    font-size: clamp(1.2rem, 2.35vw, 1.5rem);
-    line-height: 1.32;
-    font-weight: 700;
-    letter-spacing: -0.015em;
+    font-size: clamp(1.45rem, 3vw, 2.25rem);
+    line-height: 1.1;
+    font-weight: 760;
+    letter-spacing: -0.035em;
+    max-width: 18ch;
 }
 
 .home-post-link {
-    color: #f2f7ff;
+    color: var(--text-primary);
     text-decoration: none;
 }
 
 .home-post-link:hover {
-    color: #9fd4ff;
+    color: var(--accent-strong);
     text-decoration: none;
 }
 
 .home-post-tags {
-    margin-top: 0.75rem;
+    margin-top: 1rem;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.42rem;
+    gap: 0.5rem;
 }
 
 .home-post-tag {
     display: inline-block;
-    padding: 0.22rem 0.56rem;
-    border-radius: 2px;
-    border: 1px solid rgba(136, 191, 236, 0.28);
-    background: rgba(116, 184, 241, 0.1);
-    color: #bde4ff;
-    font-size: 0.74rem;
+    padding: 0.28rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid var(--panel-border);
+    background: rgba(9, 17, 31, 0.84);
+    color: var(--accent-strong);
+    font-size: 0.72rem;
     font-weight: 600;
-    letter-spacing: 0.015em;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
     text-decoration: none;
 }
 
 .home-post-tag:hover {
     text-decoration: none;
     color: #ebf7ff;
-    border-color: rgba(183, 227, 255, 0.62);
-    background: rgba(116, 184, 241, 0.2);
+    border-color: var(--panel-border-strong);
+    background: var(--accent-wash);
 }
 
 @media (max-width: 768px) {
     body.home main.home-main,
-    body.tag-page main.home-main {
-        padding: 0 0.5rem;
+    body.tag-page main.home-main,
+    body.post-page main.post-main {
+        padding: 0 0.55rem;
     }
 
     .home-post-card {
-        padding: 0.95rem 0.9rem 0.95rem;
-        border-radius: 2px;
+        padding: 1.2rem 1rem 1.2rem;
+        border-radius: 22px;
     }
 
     .home-post-date {
@@ -386,5 +452,11 @@ body.tag-page main.home-main {
 
     .tag-page-lead {
         margin-bottom: 0.85rem;
+        padding: 1.2rem 1rem 1rem;
+        border-radius: 22px;
+    }
+
+    .home-post-title {
+        font-size: clamp(1.3rem, 7vw, 1.75rem);
     }
 }

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -1,6 +1,7 @@
 /* Force a vertical scrollbar to always appear */
 html {
     overflow-y: scroll;
+    background-color: var(--page-bg);
 }
 
 :root {
@@ -216,6 +217,12 @@ th {
 /* Override the bg-dark class to make it black */
 .bg-dark {
     background-color: transparent !important;
+}
+
+body.bg-dark.home,
+body.bg-dark.tag-page,
+body.bg-dark.post-page {
+    background-color: var(--page-bg) !important;
 }
 
 hr {

--- a/docs/static/styles.css
+++ b/docs/static/styles.css
@@ -6,23 +6,21 @@ html {
 :root {
     --page-bg: #02060d;
     --page-bg-soft: #08111e;
-    --panel-bg: rgba(6, 12, 22, 0.9);
-    --panel-bg-strong: rgba(4, 9, 17, 0.96);
-    --panel-border: rgba(136, 188, 255, 0.16);
-    --panel-border-strong: rgba(136, 188, 255, 0.28);
+    --panel-bg: #06101c;
+    --panel-bg-strong: #040911;
+    --panel-border: rgba(136, 188, 255, 0.12);
+    --panel-border-strong: rgba(136, 188, 255, 0.24);
     --text-primary: #f4f8ff;
     --text-muted: #99adc8;
     --text-soft: #cad6e8;
     --accent: #77b9ff;
     --accent-strong: #a6d5ff;
     --accent-wash: rgba(119, 185, 255, 0.12);
-    --surface-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+    --surface-shadow: none;
 }
 
 body {
-    background:
-        radial-gradient(circle at top center, rgba(62, 118, 196, 0.2), transparent 34%),
-        linear-gradient(180deg, #02050b 0%, #040912 48%, #02060d 100%);
+    background: var(--page-bg);
     color: var(--text-primary);
 }
 
@@ -55,7 +53,7 @@ body.home main.home-main {
     pointer-events: none;
     z-index: -1;
     opacity: 0.55;
-    background: radial-gradient(circle at top right, rgba(34, 153, 255, 0.25), rgba(0, 0, 0, 0.85));
+    background: #02060d;
     filter: saturate(140%);
 }
 
@@ -153,14 +151,14 @@ pre code {
 }
 
 .post-tag {
-    background-color: rgba(10, 18, 32, 0.92);
+    background-color: #0b1726;
     color: var(--accent-strong);
     padding: 5px 8px;
-    border-radius: 999px;
+    border-radius: 2px;
     font-size: 0.8em;
     margin-left: 5px;
     display: inline-block;
-    border: 1px solid var(--panel-border);
+    border: 0;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
@@ -184,8 +182,8 @@ table {
     width: 100%;
     margin-bottom: 1em;
     border: 1px solid #4b5563; /* Slightly thinner border */
-    border-radius: 8px; /* Rounded corners */
-    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.2); /* Subtle shadow for depth */
+    border-radius: 0;
+    box-shadow: none;
 }
 
 th, td {
@@ -207,13 +205,11 @@ th {
 
 
 #footer-container, #header-container {
-    background-color: rgba(6, 11, 20, 0.82) !important;
+    background-color: var(--panel-bg-strong) !important;
     padding: 1em;
-    border-radius: 18px;
-    border: 1px solid var(--panel-border);
+    border-radius: 0;
+    border: 0;
     box-shadow: var(--surface-shadow);
-    -webkit-backdrop-filter: blur(18px);
-    backdrop-filter: blur(18px);
 }
 
 
@@ -238,8 +234,7 @@ body.post-page #header-container,
 body.post-page #footer-container,
 body.tag-page #header-container,
 body.tag-page #footer-container {
-    background:
-        linear-gradient(180deg, rgba(8, 15, 28, 0.95), rgba(4, 9, 17, 0.94)) !important;
+    background: var(--panel-bg-strong) !important;
 }
 
 body.home .home-link,
@@ -265,10 +260,10 @@ body.tag-page .home-link h2 {
 body.home .about-link,
 body.post-page .about-link,
 body.tag-page .about-link {
-    border-color: var(--panel-border-strong);
+    border-color: transparent;
     color: var(--accent-strong);
-    background: rgba(9, 18, 34, 0.78);
-    border-radius: 999px;
+    background: #0b1726;
+    border-radius: 2px;
     padding: 0.45rem 0.95rem;
     font-size: 0.76rem;
     letter-spacing: 0.12em;
@@ -294,10 +289,9 @@ body.post-page main.post-main {
 .tag-page-lead {
     margin: 0 auto 1.2rem;
     padding: 1.5rem 1.25rem 1.25rem;
-    border: 1px solid var(--panel-border);
-    border-radius: 28px;
-    background:
-        linear-gradient(180deg, rgba(9, 18, 33, 0.95), rgba(5, 10, 18, 0.96));
+    border: 0;
+    border-radius: 0;
+    background: var(--panel-bg);
     box-shadow: var(--surface-shadow);
 }
 
@@ -349,29 +343,22 @@ body.post-page main.post-main {
 .home-post-card {
     position: relative;
     padding: 1.5rem 1.45rem 1.5rem;
-    border-radius: 28px;
-    border: 1px solid var(--panel-border);
-    background:
-        linear-gradient(180deg, rgba(8, 16, 29, 0.96), rgba(4, 10, 18, 0.98));
+    border-radius: 0;
+    border: 0;
+    border-left: 2px solid transparent;
+    background: var(--panel-bg);
     box-shadow: var(--surface-shadow);
     overflow: hidden;
-    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+    transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .home-post-card::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(143, 201, 255, 0.55), transparent);
-    opacity: 0.8;
+    content: none;
 }
 
 .home-post-card:hover {
-    transform: translateY(-2px);
-    border-color: var(--panel-border-strong);
-    background:
-        linear-gradient(180deg, rgba(10, 21, 38, 0.98), rgba(5, 11, 21, 0.99));
+    border-left-color: var(--accent);
+    background: #071422;
 }
 
 .home-post-topline {
@@ -416,9 +403,9 @@ body.post-page main.post-main {
 .home-post-tag {
     display: inline-block;
     padding: 0.28rem 0.7rem;
-    border-radius: 999px;
-    border: 1px solid var(--panel-border);
-    background: rgba(9, 17, 31, 0.84);
+    border-radius: 2px;
+    border: 0;
+    background: #0b1726;
     color: var(--accent-strong);
     font-size: 0.72rem;
     font-weight: 600;
@@ -430,7 +417,6 @@ body.post-page main.post-main {
 .home-post-tag:hover {
     text-decoration: none;
     color: #ebf7ff;
-    border-color: var(--panel-border-strong);
     background: var(--accent-wash);
 }
 
@@ -443,7 +429,7 @@ body.post-page main.post-main {
 
     .home-post-card {
         padding: 1.2rem 1rem 1.2rem;
-        border-radius: 22px;
+        border-radius: 0;
     }
 
     .home-post-date {
@@ -453,7 +439,7 @@ body.post-page main.post-main {
     .tag-page-lead {
         margin-bottom: 0.85rem;
         padding: 1.2rem 1rem 1rem;
-        border-radius: 22px;
+        border-radius: 0;
     }
 
     .home-post-title {

--- a/static/post-reading.css
+++ b/static/post-reading.css
@@ -155,7 +155,7 @@
 .post-reading img {
     max-width: 100%;
     height: auto;
-    border-radius: 0;
+    border-radius: 0 !important;
     margin: 2em 0;
     display: block;
 }
@@ -169,7 +169,7 @@
     width: calc(100% + 4rem);
     max-width: calc(100% + 4rem);
     margin: 0;
-    border-radius: 0;
+    border-radius: 0 !important;
 }
 
 .post-reading figcaption {

--- a/static/post-reading.css
+++ b/static/post-reading.css
@@ -16,7 +16,7 @@
     padding: 2rem 1.5rem 4rem;
     line-height: 1.8;
     font-size: 1.125rem;
-    color: #e8e6e3;
+    color: #dce6f6;
 }
 
 /* --- Typography --- */
@@ -27,7 +27,7 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-weight: 700;
     letter-spacing: -0.02em;
-    color: #ffffff;
+    color: #f6f9ff;
     margin-top: 2.5em;
     margin-bottom: 0.6em;
     line-height: 1.25;
@@ -52,7 +52,7 @@
 .post-reading p,
 .post-reading li {
     font-family: Georgia, 'Times New Roman', serif;
-    color: #d4d0cb;
+    color: #d4ddef;
 }
 
 .post-reading p {
@@ -60,15 +60,15 @@
 }
 
 .post-reading a {
-    color: #6cb4ee;
+    color: #8fc9ff;
     text-decoration: underline;
-    text-decoration-color: rgba(108, 180, 238, 0.3);
+    text-decoration-color: rgba(143, 201, 255, 0.34);
     text-underline-offset: 3px;
     transition: text-decoration-color 0.2s;
 }
 
 .post-reading a:hover {
-    text-decoration-color: rgba(108, 180, 238, 0.8);
+    text-decoration-color: rgba(143, 201, 255, 0.9);
 }
 
 .post-reading strong {
@@ -93,18 +93,18 @@
 }
 
 .post-reading li::marker {
-    color: #6cb4ee;
+    color: #8fc9ff;
 }
 
 /* --- Blockquotes / Pull quotes --- */
 .post-reading blockquote {
-    border-left: 3px solid #6cb4ee;
-    background: rgba(108, 180, 238, 0.05);
+    border-left: 3px solid #8fc9ff;
+    background: rgba(143, 201, 255, 0.06);
     padding: 1.25em 1.5em;
     margin: 2em 0;
     border-radius: 0 8px 8px 0;
     font-style: italic;
-    color: #b8b4af;
+    color: #c3d2e7;
 }
 
 .post-reading blockquote p {
@@ -119,7 +119,7 @@
 .post-reading blockquote strong {
     font-style: normal;
     font-size: 1.15em;
-    color: #e8e6e3;
+    color: #ecf3ff;
     display: block;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.4;
@@ -136,8 +136,8 @@
 }
 
 .post-reading .callout-info {
-    border-left: 4px solid #6cb4ee;
-    background: rgba(108, 180, 238, 0.04);
+    border-left: 4px solid #8fc9ff;
+    background: rgba(143, 201, 255, 0.05);
 }
 
 .post-reading .callout-warning {
@@ -146,8 +146,8 @@
 }
 
 .post-reading .callout-success {
-    border-left: 4px solid #4caf7d;
-    background: rgba(76, 175, 125, 0.04);
+    border-left: 4px solid #6fb8ff;
+    background: rgba(111, 184, 255, 0.05);
 }
 
 /* --- Figures & images --- */
@@ -187,7 +187,7 @@
     background: rgba(255, 255, 255, 0.06);
     padding: 0.2em 0.4em;
     border-radius: 4px;
-    color: #e0ddd8;
+    color: #e7eefc;
 }
 
 .post-reading pre {
@@ -263,7 +263,7 @@
 }
 
 .post-reading sup a {
-    color: #6cb4ee;
+    color: #8fc9ff;
     text-decoration: none;
     font-weight: 600;
 }
@@ -271,46 +271,97 @@
 /* --- Post header --- */
 .post-hero {
     max-width: 680px;
-    margin: 0 auto 0.95rem;
-    padding: 1.1rem 1.15rem 1.2rem;
-    border-radius: 3px;
-    border: 1px solid rgba(255, 255, 255, 0.09);
-    background: rgba(8, 13, 22, 0.9);
+    margin: 0 auto 1rem;
+    padding: 1.15rem 1.15rem 1.5rem;
+    border-radius: 28px;
+    border: 1px solid rgba(136, 188, 255, 0.18);
+    background:
+        linear-gradient(180deg, rgba(9, 18, 33, 0.96), rgba(4, 9, 17, 0.98));
+    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+    text-align: center;
 }
 
 .post-hero h1 {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-size: clamp(1.45rem, 3.5vw, 2rem);
+    font-size: clamp(2rem, 4.8vw, 3.55rem);
     font-weight: 760;
-    letter-spacing: -0.015em;
-    line-height: 1.24;
+    letter-spacing: -0.05em;
+    line-height: 1.03;
     color: #f2f7ff;
     margin: 0;
+    text-wrap: balance;
+}
+
+.post-back-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1.6rem;
+    color: #cad6e8;
+    text-decoration: none;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+.post-back-link::before {
+    content: "←";
+    margin-right: 0.7rem;
+    font-size: 1rem;
+}
+
+.post-back-link:hover {
+    color: #ffffff;
+    text-decoration: none;
+}
+
+.post-kicker-row {
+    margin-bottom: 0.95rem;
+}
+
+.post-kicker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.38rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid rgba(143, 201, 255, 0.2);
+    background: rgba(111, 184, 255, 0.12);
+    color: #d4eaff;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
 .post-meta-bar {
     display: flex;
     align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
     gap: 0.65em;
-    margin-top: 0.58rem;
+    margin-top: 1rem;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-size: 0.8rem;
-    color: #89bde2;
-    letter-spacing: 0.045em;
+    font-size: 0.78rem;
+    color: #99adc8;
+    letter-spacing: 0.16em;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
     text-transform: uppercase;
     font-weight: 600;
 }
 
 .post-meta-bar time {
-    color: #89bde2;
+    color: #99adc8;
 }
 
 .post-meta-bar .reading-time {
-    color: #89bde2;
+    color: #99adc8;
 }
 
 .post-meta-bar .separator {
-    color: rgba(137, 189, 226, 0.85);
+    color: rgba(153, 173, 200, 0.85);
 }
 
 /* --- Scroll progress bar --- */
@@ -319,7 +370,7 @@
     top: 0;
     left: 0;
     height: 3px;
-    background: linear-gradient(to right, #6cb4ee, #a78bfa);
+    background: linear-gradient(to right, #77b9ff, #c8e4ff);
     width: 0%;
     z-index: 9999;
     transition: width 0.1s linear;
@@ -333,9 +384,9 @@
 }
 
 .post-toc details {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 8px;
+    background: rgba(7, 13, 24, 0.82);
+    border: 1px solid rgba(136, 188, 255, 0.12);
+    border-radius: 18px;
     padding: 1em 1.25em;
     margin-bottom: 0.75em;
 }
@@ -348,7 +399,7 @@
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 0.85rem;
     font-weight: 600;
-    color: #999;
+    color: #99adc8;
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -390,7 +441,7 @@
 }
 
 .post-toc a:hover {
-    color: #6cb4ee;
+    color: #8fc9ff;
 }
 
 .post-toc .toc-h3 {
@@ -402,34 +453,36 @@
     max-width: 680px;
     margin: 0 auto;
     padding: 2rem 1.5rem 3rem;
-    border-top: 1px solid rgba(255,255,255,0.06);
+    border-top: 1px solid rgba(136, 188, 255, 0.1);
 }
 
 .post-tags-footer .post-tag {
-    background: rgba(255,255,255,0.05);
-    border: 1px solid rgba(255,255,255,0.08);
-    color: #aaa;
+    background: rgba(9, 17, 31, 0.84);
+    border: 1px solid rgba(136, 188, 255, 0.16);
+    color: #a6d5ff;
     padding: 0.4em 0.8em;
-    border-radius: 6px;
-    font-size: 0.8rem;
+    border-radius: 999px;
+    font-size: 0.74rem;
     margin-right: 0.5em;
     margin-bottom: 0.5em;
     display: inline-block;
     transition: all 0.2s;
     text-decoration: none;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .post-tags-footer .post-tag:hover {
-    background: rgba(108, 180, 238, 0.1);
-    border-color: rgba(108, 180, 238, 0.3);
-    color: #6cb4ee;
+    background: rgba(119, 185, 255, 0.12);
+    border-color: rgba(166, 213, 255, 0.34);
+    color: #eff7ff;
 }
 
 /* --- Responsive --- */
 @media (max-width: 720px) {
     .post-hero h1 {
-        font-size: clamp(1.25rem, 7vw, 1.6rem);
+        font-size: clamp(1.7rem, 9vw, 2.35rem);
     }
     
     .post-reading {
@@ -463,8 +516,14 @@
 
     .post-hero {
         margin-bottom: 0.8rem;
-        padding-top: 0.95rem;
-        padding-bottom: 1rem;
+        padding-top: 1rem;
+        padding-bottom: 1.2rem;
+        border-radius: 22px;
+    }
+
+    .post-back-link {
+        margin-bottom: 1.2rem;
+        font-size: 0.73rem;
     }
 }
 

--- a/static/post-reading.css
+++ b/static/post-reading.css
@@ -102,7 +102,7 @@
     background: rgba(143, 201, 255, 0.06);
     padding: 1.25em 1.5em;
     margin: 2em 0;
-    border-radius: 0 8px 8px 0;
+    border-radius: 0;
     font-style: italic;
     color: #c3d2e7;
 }
@@ -129,8 +129,9 @@
 /* Use in markdown: <div class="callout"> ... </div> */
 .post-reading .callout {
     background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 12px;
+    border: 0;
+    border-left: 3px solid rgba(143, 201, 255, 0.45);
+    border-radius: 0;
     padding: 1.5em 1.75em;
     margin: 2em 0;
 }
@@ -154,7 +155,7 @@
 .post-reading img {
     max-width: 100%;
     height: auto;
-    border-radius: 8px;
+    border-radius: 0;
     margin: 2em 0;
     display: block;
 }
@@ -168,7 +169,7 @@
     width: calc(100% + 4rem);
     max-width: calc(100% + 4rem);
     margin: 0;
-    border-radius: 8px;
+    border-radius: 0;
 }
 
 .post-reading figcaption {
@@ -186,19 +187,19 @@
     font-size: 0.85em;
     background: rgba(255, 255, 255, 0.06);
     padding: 0.2em 0.4em;
-    border-radius: 4px;
+    border-radius: 2px;
     color: #e7eefc;
 }
 
 .post-reading pre {
     margin: 2em -1rem;
     padding: 1.25em 1.5em;
-    border-radius: 8px;
+    border-radius: 0;
     overflow-x: auto;
     font-size: 0.875rem;
     line-height: 1.6;
     background: #111 !important;
-    border: 1px solid rgba(255,255,255,0.06);
+    border: 0;
 }
 
 .post-reading pre code {
@@ -240,7 +241,7 @@
 .post-reading hr {
     border: none;
     height: 1px;
-    background: linear-gradient(to right, transparent, rgba(255,255,255,0.12), transparent);
+    background: rgba(255,255,255,0.12);
     margin: 3em 0;
 }
 
@@ -273,11 +274,10 @@
     max-width: 680px;
     margin: 0 auto 1rem;
     padding: 1.15rem 1.15rem 1.5rem;
-    border-radius: 28px;
-    border: 1px solid rgba(136, 188, 255, 0.18);
-    background:
-        linear-gradient(180deg, rgba(9, 18, 33, 0.96), rgba(4, 9, 17, 0.98));
-    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+    border-radius: 0;
+    border: 0;
+    background: #06101c;
+    box-shadow: none;
     text-align: center;
 }
 
@@ -325,9 +325,9 @@
     align-items: center;
     justify-content: center;
     padding: 0.38rem 0.8rem;
-    border-radius: 999px;
-    border: 1px solid rgba(143, 201, 255, 0.2);
-    background: rgba(111, 184, 255, 0.12);
+    border-radius: 2px;
+    border: 0;
+    background: #0b1726;
     color: #d4eaff;
     font-size: 0.72rem;
     font-weight: 700;
@@ -370,7 +370,7 @@
     top: 0;
     left: 0;
     height: 3px;
-    background: linear-gradient(to right, #77b9ff, #c8e4ff);
+    background: #77b9ff;
     width: 0%;
     z-index: 9999;
     transition: width 0.1s linear;
@@ -384,9 +384,9 @@
 }
 
 .post-toc details {
-    background: rgba(7, 13, 24, 0.82);
-    border: 1px solid rgba(136, 188, 255, 0.12);
-    border-radius: 18px;
+    background: #06101c;
+    border: 0;
+    border-radius: 0;
     padding: 1em 1.25em;
     margin-bottom: 0.75em;
 }
@@ -457,11 +457,11 @@
 }
 
 .post-tags-footer .post-tag {
-    background: rgba(9, 17, 31, 0.84);
-    border: 1px solid rgba(136, 188, 255, 0.16);
+    background: #0b1726;
+    border: 0;
     color: #a6d5ff;
     padding: 0.4em 0.8em;
-    border-radius: 999px;
+    border-radius: 2px;
     font-size: 0.74rem;
     margin-right: 0.5em;
     margin-bottom: 0.5em;
@@ -475,7 +475,6 @@
 
 .post-tags-footer .post-tag:hover {
     background: rgba(119, 185, 255, 0.12);
-    border-color: rgba(166, 213, 255, 0.34);
     color: #eff7ff;
 }
 
@@ -518,7 +517,7 @@
         margin-bottom: 0.8rem;
         padding-top: 1rem;
         padding-bottom: 1.2rem;
-        border-radius: 22px;
+        border-radius: 0;
     }
 
     .post-back-link {

--- a/static/styles.css
+++ b/static/styles.css
@@ -3,11 +3,39 @@ html {
     overflow-y: scroll;
 }
 
+:root {
+    --page-bg: #02060d;
+    --page-bg-soft: #08111e;
+    --panel-bg: rgba(6, 12, 22, 0.9);
+    --panel-bg-strong: rgba(4, 9, 17, 0.96);
+    --panel-border: rgba(136, 188, 255, 0.16);
+    --panel-border-strong: rgba(136, 188, 255, 0.28);
+    --text-primary: #f4f8ff;
+    --text-muted: #99adc8;
+    --text-soft: #cad6e8;
+    --accent: #77b9ff;
+    --accent-strong: #a6d5ff;
+    --accent-wash: rgba(119, 185, 255, 0.12);
+    --surface-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+}
+
+body {
+    background:
+        radial-gradient(circle at top center, rgba(62, 118, 196, 0.2), transparent 34%),
+        linear-gradient(180deg, #02050b 0%, #040912 48%, #02060d 100%);
+    color: var(--text-primary);
+}
+
 body.home {
     position: relative;
     min-height: 100vh;
     overflow-x: hidden;
-    background-color: #000;
+}
+
+body.home,
+body.tag-page,
+body.post-page {
+    background-color: var(--page-bg);
 }
 
 body.home main.home-main {
@@ -40,7 +68,7 @@ body.home main.home-main {
 
 
 blockquote {
-    border-left: 4px solid #569cd6;
+    border-left: 4px solid var(--accent);
     padding-left: 1em;
     color: #bbbbbb;
     font-style: italic;
@@ -121,18 +149,19 @@ pre code {
 .post-tags {
     margin-bottom: 0em;
     font-size: 0.9em;
-    color: #ff0000;
+    color: var(--text-soft);
 }
 
 .post-tag {
-    background-color: #1c1c1c;
-    color: #ddd;
+    background-color: rgba(10, 18, 32, 0.92);
+    color: var(--accent-strong);
     padding: 5px 8px;
-    border-radius: 4px;
+    border-radius: 999px;
     font-size: 0.8em;
     margin-left: 5px;
     display: inline-block;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    border: 1px solid var(--panel-border);
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 a.post-tag {
@@ -144,7 +173,8 @@ a.post-tag:hover {
 }
 
 .post-tag:hover {
-    background-color: #666;
+    background-color: var(--accent-wash);
+    border-color: var(--panel-border-strong);
     color: #fff;
 }
 
@@ -177,16 +207,19 @@ th {
 
 
 #footer-container, #header-container {
-    background-color: #1c1c1c !important;
+    background-color: rgba(6, 11, 20, 0.82) !important;
     padding: 1em;
-    border-radius: 10px;
+    border-radius: 18px;
+    border: 1px solid var(--panel-border);
+    box-shadow: var(--surface-shadow);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
 }
 
 
 /* Override the bg-dark class to make it black */
 .bg-dark {
-    background-color: #000 !important;
-    
+    background-color: transparent !important;
 }
 
 hr {
@@ -196,94 +229,111 @@ hr {
 /* Homepage facelift inspired by the rich post reading look */
 body.home,
 body.tag-page {
-    background-color: #07090d;
+    background-color: var(--page-bg);
 }
 
 body.home #header-container,
 body.home #footer-container,
+body.post-page #header-container,
+body.post-page #footer-container,
 body.tag-page #header-container,
 body.tag-page #footer-container {
-    background: rgba(7, 10, 16, 0.92) !important;
-    border: 1px solid rgba(255, 255, 255, 0.09);
-    box-shadow: none;
-    -webkit-backdrop-filter: blur(8px);
-    backdrop-filter: blur(8px);
+    background:
+        linear-gradient(180deg, rgba(8, 15, 28, 0.95), rgba(4, 9, 17, 0.94)) !important;
 }
 
 body.home .home-link,
 body.home .home-link:hover,
+body.post-page .home-link,
+body.post-page .home-link:hover,
 body.tag-page .home-link,
 body.tag-page .home-link:hover {
     text-decoration: none;
 }
 
 body.home .home-link h2,
+body.post-page .home-link h2,
 body.tag-page .home-link h2 {
     margin: 0;
-    font-size: 1.35rem;
+    font-size: 1.1rem;
     font-weight: 700;
-    letter-spacing: 0.02em;
-    color: #f5f8ff;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--text-primary);
 }
 
 body.home .about-link,
+body.post-page .about-link,
 body.tag-page .about-link {
-    border-color: rgba(120, 190, 255, 0.55);
-    color: #d9edff;
-    background: rgba(108, 180, 238, 0.08);
+    border-color: var(--panel-border-strong);
+    color: var(--accent-strong);
+    background: rgba(9, 18, 34, 0.78);
+    border-radius: 999px;
+    padding: 0.45rem 0.95rem;
+    font-size: 0.76rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 body.home .about-link:hover,
+body.post-page .about-link:hover,
 body.tag-page .about-link:hover {
-    background: rgba(108, 180, 238, 0.2);
-    border-color: rgba(160, 220, 255, 0.8);
+    background: var(--accent-wash);
+    border-color: rgba(166, 213, 255, 0.74);
     color: #ffffff;
 }
 
 body.home main.home-main,
-body.tag-page main.home-main {
-    max-width: 880px;
+body.tag-page main.home-main,
+body.post-page main.post-main {
+    max-width: 960px;
     margin: 1.25rem auto 2rem;
-    padding: 0 0.75rem;
+    padding: 0 0.85rem;
 }
 
 .tag-page-lead {
-    margin: 0 auto 1rem;
-    padding: 1rem 0.1rem 0.35rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    margin: 0 auto 1.2rem;
+    padding: 1.5rem 1.25rem 1.25rem;
+    border: 1px solid var(--panel-border);
+    border-radius: 28px;
+    background:
+        linear-gradient(180deg, rgba(9, 18, 33, 0.95), rgba(5, 10, 18, 0.96));
+    box-shadow: var(--surface-shadow);
 }
 
 .tag-page-kicker {
     margin: 0;
-    color: #8bc8ff;
-    font-size: 0.78rem;
+    color: var(--accent);
+    font-size: 0.74rem;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.18em;
     font-weight: 650;
 }
 
 .tag-page-title {
     margin: 0.25rem 0 0;
-    color: #f7fbff;
-    font-size: clamp(1.35rem, 3.4vw, 1.9rem);
-    line-height: 1.2;
+    color: var(--text-primary);
+    font-size: clamp(1.6rem, 4vw, 2.35rem);
+    line-height: 1.08;
     font-weight: 760;
+    max-width: 12ch;
 }
 
 .tag-page-backline {
-    margin: 0.45rem 0 0;
+    margin: 0.75rem 0 0;
 }
 
 .tag-back-link {
-    color: #b9daf5;
+    color: var(--text-soft);
     text-decoration: none;
-    border-bottom: 1px solid rgba(185, 218, 245, 0.4);
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
 }
 
 .tag-back-link:hover {
     color: #e3f1ff;
     text-decoration: none;
-    border-bottom-color: rgba(227, 241, 255, 0.7);
 }
 
 .tag-empty-state {
@@ -293,91 +343,107 @@ body.tag-page main.home-main {
 
 .home-feed {
     display: grid;
-    gap: 0.95rem;
+    gap: 1.15rem;
 }
 
 .home-post-card {
     position: relative;
-    padding: 1.1rem 1.15rem 1.2rem;
-    border-radius: 3px;
-    border: 1px solid rgba(255, 255, 255, 0.09);
-    background: rgba(8, 13, 22, 0.9);
-    box-shadow: none;
-    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    padding: 1.5rem 1.45rem 1.5rem;
+    border-radius: 28px;
+    border: 1px solid var(--panel-border);
+    background:
+        linear-gradient(180deg, rgba(8, 16, 29, 0.96), rgba(4, 10, 18, 0.98));
+    box-shadow: var(--surface-shadow);
+    overflow: hidden;
+    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.home-post-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(143, 201, 255, 0.55), transparent);
+    opacity: 0.8;
 }
 
 .home-post-card:hover {
-    transform: none;
-    border-color: rgba(130, 196, 255, 0.3);
-    box-shadow: none;
+    transform: translateY(-2px);
+    border-color: var(--panel-border-strong);
+    background:
+        linear-gradient(180deg, rgba(10, 21, 38, 0.98), rgba(5, 11, 21, 0.99));
 }
 
 .home-post-topline {
-    margin: 0 0 0.35rem;
+    margin: 0 0 0.85rem;
 }
 
 .home-post-date {
-    color: #89bde2;
-    font-size: 0.82rem;
+    color: var(--text-muted);
+    font-size: 0.78rem;
     font-weight: 600;
-    letter-spacing: 0.045em;
+    letter-spacing: 0.16em;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
     text-transform: uppercase;
 }
 
 .home-post-title {
     margin: 0;
-    font-size: clamp(1.2rem, 2.35vw, 1.5rem);
-    line-height: 1.32;
-    font-weight: 700;
-    letter-spacing: -0.015em;
+    font-size: clamp(1.45rem, 3vw, 2.25rem);
+    line-height: 1.1;
+    font-weight: 760;
+    letter-spacing: -0.035em;
+    max-width: 18ch;
 }
 
 .home-post-link {
-    color: #f2f7ff;
+    color: var(--text-primary);
     text-decoration: none;
 }
 
 .home-post-link:hover {
-    color: #9fd4ff;
+    color: var(--accent-strong);
     text-decoration: none;
 }
 
 .home-post-tags {
-    margin-top: 0.75rem;
+    margin-top: 1rem;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.42rem;
+    gap: 0.5rem;
 }
 
 .home-post-tag {
     display: inline-block;
-    padding: 0.22rem 0.56rem;
-    border-radius: 2px;
-    border: 1px solid rgba(136, 191, 236, 0.28);
-    background: rgba(116, 184, 241, 0.1);
-    color: #bde4ff;
-    font-size: 0.74rem;
+    padding: 0.28rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid var(--panel-border);
+    background: rgba(9, 17, 31, 0.84);
+    color: var(--accent-strong);
+    font-size: 0.72rem;
     font-weight: 600;
-    letter-spacing: 0.015em;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
     text-decoration: none;
 }
 
 .home-post-tag:hover {
     text-decoration: none;
     color: #ebf7ff;
-    border-color: rgba(183, 227, 255, 0.62);
-    background: rgba(116, 184, 241, 0.2);
+    border-color: var(--panel-border-strong);
+    background: var(--accent-wash);
 }
 
 @media (max-width: 768px) {
     body.home main.home-main,
-    body.tag-page main.home-main {
-        padding: 0 0.5rem;
+    body.tag-page main.home-main,
+    body.post-page main.post-main {
+        padding: 0 0.55rem;
     }
 
     .home-post-card {
-        padding: 0.95rem 0.9rem 0.95rem;
-        border-radius: 2px;
+        padding: 1.2rem 1rem 1.2rem;
+        border-radius: 22px;
     }
 
     .home-post-date {
@@ -386,5 +452,11 @@ body.tag-page main.home-main {
 
     .tag-page-lead {
         margin-bottom: 0.85rem;
+        padding: 1.2rem 1rem 1rem;
+        border-radius: 22px;
+    }
+
+    .home-post-title {
+        font-size: clamp(1.3rem, 7vw, 1.75rem);
     }
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,6 +1,7 @@
 /* Force a vertical scrollbar to always appear */
 html {
     overflow-y: scroll;
+    background-color: var(--page-bg);
 }
 
 :root {
@@ -216,6 +217,12 @@ th {
 /* Override the bg-dark class to make it black */
 .bg-dark {
     background-color: transparent !important;
+}
+
+body.bg-dark.home,
+body.bg-dark.tag-page,
+body.bg-dark.post-page {
+    background-color: var(--page-bg) !important;
 }
 
 hr {

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,23 +6,21 @@ html {
 :root {
     --page-bg: #02060d;
     --page-bg-soft: #08111e;
-    --panel-bg: rgba(6, 12, 22, 0.9);
-    --panel-bg-strong: rgba(4, 9, 17, 0.96);
-    --panel-border: rgba(136, 188, 255, 0.16);
-    --panel-border-strong: rgba(136, 188, 255, 0.28);
+    --panel-bg: #06101c;
+    --panel-bg-strong: #040911;
+    --panel-border: rgba(136, 188, 255, 0.12);
+    --panel-border-strong: rgba(136, 188, 255, 0.24);
     --text-primary: #f4f8ff;
     --text-muted: #99adc8;
     --text-soft: #cad6e8;
     --accent: #77b9ff;
     --accent-strong: #a6d5ff;
     --accent-wash: rgba(119, 185, 255, 0.12);
-    --surface-shadow: 0 24px 72px rgba(0, 0, 0, 0.36);
+    --surface-shadow: none;
 }
 
 body {
-    background:
-        radial-gradient(circle at top center, rgba(62, 118, 196, 0.2), transparent 34%),
-        linear-gradient(180deg, #02050b 0%, #040912 48%, #02060d 100%);
+    background: var(--page-bg);
     color: var(--text-primary);
 }
 
@@ -55,7 +53,7 @@ body.home main.home-main {
     pointer-events: none;
     z-index: -1;
     opacity: 0.55;
-    background: radial-gradient(circle at top right, rgba(34, 153, 255, 0.25), rgba(0, 0, 0, 0.85));
+    background: #02060d;
     filter: saturate(140%);
 }
 
@@ -153,14 +151,14 @@ pre code {
 }
 
 .post-tag {
-    background-color: rgba(10, 18, 32, 0.92);
+    background-color: #0b1726;
     color: var(--accent-strong);
     padding: 5px 8px;
-    border-radius: 999px;
+    border-radius: 2px;
     font-size: 0.8em;
     margin-left: 5px;
     display: inline-block;
-    border: 1px solid var(--panel-border);
+    border: 0;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
@@ -184,8 +182,8 @@ table {
     width: 100%;
     margin-bottom: 1em;
     border: 1px solid #4b5563; /* Slightly thinner border */
-    border-radius: 8px; /* Rounded corners */
-    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.2); /* Subtle shadow for depth */
+    border-radius: 0;
+    box-shadow: none;
 }
 
 th, td {
@@ -207,13 +205,11 @@ th {
 
 
 #footer-container, #header-container {
-    background-color: rgba(6, 11, 20, 0.82) !important;
+    background-color: var(--panel-bg-strong) !important;
     padding: 1em;
-    border-radius: 18px;
-    border: 1px solid var(--panel-border);
+    border-radius: 0;
+    border: 0;
     box-shadow: var(--surface-shadow);
-    -webkit-backdrop-filter: blur(18px);
-    backdrop-filter: blur(18px);
 }
 
 
@@ -238,8 +234,7 @@ body.post-page #header-container,
 body.post-page #footer-container,
 body.tag-page #header-container,
 body.tag-page #footer-container {
-    background:
-        linear-gradient(180deg, rgba(8, 15, 28, 0.95), rgba(4, 9, 17, 0.94)) !important;
+    background: var(--panel-bg-strong) !important;
 }
 
 body.home .home-link,
@@ -265,10 +260,10 @@ body.tag-page .home-link h2 {
 body.home .about-link,
 body.post-page .about-link,
 body.tag-page .about-link {
-    border-color: var(--panel-border-strong);
+    border-color: transparent;
     color: var(--accent-strong);
-    background: rgba(9, 18, 34, 0.78);
-    border-radius: 999px;
+    background: #0b1726;
+    border-radius: 2px;
     padding: 0.45rem 0.95rem;
     font-size: 0.76rem;
     letter-spacing: 0.12em;
@@ -294,10 +289,9 @@ body.post-page main.post-main {
 .tag-page-lead {
     margin: 0 auto 1.2rem;
     padding: 1.5rem 1.25rem 1.25rem;
-    border: 1px solid var(--panel-border);
-    border-radius: 28px;
-    background:
-        linear-gradient(180deg, rgba(9, 18, 33, 0.95), rgba(5, 10, 18, 0.96));
+    border: 0;
+    border-radius: 0;
+    background: var(--panel-bg);
     box-shadow: var(--surface-shadow);
 }
 
@@ -349,29 +343,22 @@ body.post-page main.post-main {
 .home-post-card {
     position: relative;
     padding: 1.5rem 1.45rem 1.5rem;
-    border-radius: 28px;
-    border: 1px solid var(--panel-border);
-    background:
-        linear-gradient(180deg, rgba(8, 16, 29, 0.96), rgba(4, 10, 18, 0.98));
+    border-radius: 0;
+    border: 0;
+    border-left: 2px solid transparent;
+    background: var(--panel-bg);
     box-shadow: var(--surface-shadow);
     overflow: hidden;
-    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+    transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .home-post-card::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(143, 201, 255, 0.55), transparent);
-    opacity: 0.8;
+    content: none;
 }
 
 .home-post-card:hover {
-    transform: translateY(-2px);
-    border-color: var(--panel-border-strong);
-    background:
-        linear-gradient(180deg, rgba(10, 21, 38, 0.98), rgba(5, 11, 21, 0.99));
+    border-left-color: var(--accent);
+    background: #071422;
 }
 
 .home-post-topline {
@@ -416,9 +403,9 @@ body.post-page main.post-main {
 .home-post-tag {
     display: inline-block;
     padding: 0.28rem 0.7rem;
-    border-radius: 999px;
-    border: 1px solid var(--panel-border);
-    background: rgba(9, 17, 31, 0.84);
+    border-radius: 2px;
+    border: 0;
+    background: #0b1726;
     color: var(--accent-strong);
     font-size: 0.72rem;
     font-weight: 600;
@@ -430,7 +417,6 @@ body.post-page main.post-main {
 .home-post-tag:hover {
     text-decoration: none;
     color: #ebf7ff;
-    border-color: var(--panel-border-strong);
     background: var(--accent-wash);
 }
 
@@ -443,7 +429,7 @@ body.post-page main.post-main {
 
     .home-post-card {
         padding: 1.2rem 1rem 1.2rem;
-        border-radius: 22px;
+        border-radius: 0;
     }
 
     .home-post-date {
@@ -453,7 +439,7 @@ body.post-page main.post-main {
     .tag-page-lead {
         margin-bottom: 0.85rem;
         padding: 1.2rem 1rem 1rem;
-        border-radius: 22px;
+        border-radius: 0;
     }
 
     .home-post-title {

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block title %}{{ title }}{% endblock %}
+{% block body_class %}post-page{% endblock %}
+{% block main_class %}post-main{% endblock %}
 
 {% block extra_head %}
 <link
@@ -10,28 +12,34 @@
     crossorigin=""
 >
 <link rel="stylesheet" href="{{ url_for('static', filename='map-embed.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='post-reading.css') }}">
 {% endblock %}
 
 {% block content %}
 <style>
     {{ pygments_css | safe }}
 </style>
-<div class="container bg-dark text-light">
-    <article>
-        
-        <h1 class="text-light">{{ title }}</h1>
-        <!-- Post content -->
-        {{ content | safe }}
-        <!-- Display the tags at the bottom -->
-        {% if tag_objs %}
-        <p class="post-tags text-light">
-            {% for tag in tag_objs %}
-                <a class="post-tag tag-link" href="{{ url_for('tag', tag_slug_value=tag.slug) }}">{{ tag.name }}</a>{% if not loop.last %} {% endif %}
-            {% endfor %}
-        </p>
-        {% endif %}
-    </article>
-</div>
+<header class="post-hero post-hero-legacy">
+    <a href="{{ url_for('index') }}" class="post-back-link">Back to blog</a>
+    {% if tag_objs %}
+    <div class="post-kicker-row">
+        <span class="post-kicker">{{ tag_objs[0].name }}</span>
+    </div>
+    {% endif %}
+    <h1>{{ title }}</h1>
+</header>
+
+<article class="post-reading post-reading-legacy">
+    {{ content | safe }}
+</article>
+
+{% if tag_objs %}
+<footer class="post-tags-footer">
+    {% for tag in tag_objs %}
+        <a class="post-tag tag-link" href="{{ url_for('tag', tag_slug_value=tag.slug) }}">{{ tag.name }}</a>
+    {% endfor %}
+</footer>
+{% endif %}
 
 <script src="{{ url_for('static', filename='copy-code.js') }}"></script>
 

--- a/templates/post_rich.html
+++ b/templates/post_rich.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block title %}{{ title }}{% endblock %}
+{% block body_class %}post-page{% endblock %}
+{% block main_class %}post-main{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='post-reading.css') }}">
@@ -13,6 +15,12 @@
 
 <!-- Post header -->
 <header class="post-hero">
+    <a href="{{ url_for('index') }}" class="post-back-link">Back to blog</a>
+    {% if tag_objs %}
+    <div class="post-kicker-row">
+        <span class="post-kicker">{{ tag_objs[0].name }}</span>
+    </div>
+    {% endif %}
     <h1>{{ title }}</h1>
     <div class="post-meta-bar">
         {% if date %}


### PR DESCRIPTION
## Summary
- restyle the homepage and tag listings with a darker GitHub-blog-inspired blue palette
- unify rich and legacy post pages around a shared centered hero, back link, and tag treatment
- regenerate the frozen `docs/` output so the PR is reviewable as-rendered

## Testing
- `./scripts/freeze_and_stage.sh`
